### PR TITLE
docs(scrt4): document import and cloud-crypt commands in README

### DIFF
--- a/scrt4/README.md
+++ b/scrt4/README.md
@@ -51,6 +51,7 @@ scrt4 view
 | `scrt4 status` | Check session status |
 | `scrt4 list [--tags]` | List secret names (with optional tags) |
 | `scrt4 add KEY=value` | Add a secret |
+| `scrt4 import <file>` | Import secrets from a `.env` file |
 | `scrt4 run 'cmd $env[KEY]'` | Run command with secret injection |
 | `scrt4 view` | View/edit secrets in GUI |
 | `scrt4 share` | Share secrets to another machine (wormhole) |
@@ -58,6 +59,7 @@ scrt4 view
 | `scrt4 encrypt-folder <path>` | Encrypt a folder to `.scrt4` archive |
 | `scrt4 decrypt-folder <archive>` | Decrypt a `.scrt4` archive |
 | `scrt4 backup-vault` | Backup encrypted vault to tar.gz |
+| `scrt4 cloud-crypt encrypt-and-push <path>` | Encrypt vault locally and push to your Google Drive |
 | `scrt4 backup-key [--save DIR]` | Show or save master key (requires auth) |
 | `scrt4 recover <backup.json>` | Recover from encrypted master key backup |
 | `scrt4 backup-guide` | Show backup & recovery guide |


### PR DESCRIPTION
## Summary

The `Commands` table in `scrt4/README.md` was missing two commands that the CLI already ships:

- `scrt4 import <file>` — bulk-import secrets from a `.env` file. Useful when migrating an existing project rather than re-typing every key one at a time.
- `scrt4 cloud-crypt encrypt-and-push <path>` — encrypt the vault locally and push the ciphertext to your own Google Drive. Recommended recovery path alongside saving the master key, since losing the authenticator without a backup = lost vault.

Both are referenced in the installer's first-run flow but weren't surfaced on the README's at-a-glance command list. Pure docs change — no code touched.

## Test plan

- [x] Visually inspect `scrt4/README.md` — the two new rows appear in the right groupings (`import` next to `add`, `cloud-crypt encrypt-and-push` next to `backup-vault`).
- [x] No code changes; existing CI should pass unchanged.
