### PR TITLE
fix(scrt4): accept unit-suffixed TTL (`48h`, `30m`, `2d`) in unlock/extend

### DIFF
--- a/scrt4/daemon/bin/scrt4-core
+++ b/scrt4/daemon/bin/scrt4-core
@@ -340,6 +340,49 @@ sys.stdout.buffer.write(b''.join(chunks))
 }
 export -f send_request
 
+# ── TTL parsing ──────────────────────────────────────────────────────
+#
+# _parse_ttl INPUT — convert a TTL like "48h", "30m", "2d", "3600s", or a
+# bare integer (seconds) into integer seconds on stdout. Returns 0 on
+# success, 1 on invalid input (with an error on stderr).
+#
+# Accepts: integer >= 1, optionally suffixed with one of:
+#   s  seconds
+#   m  minutes  (× 60)
+#   h  hours    (× 3600)
+#   d  days     (× 86400)
+#
+# A bare integer is treated as seconds (back-compatible with prior
+# behaviour where `scrt4 unlock 7200` meant 7200 seconds). The unit
+# suffixes are the new behaviour: previously, `scrt4 unlock 48h` died
+# inside `jq --argjson` with a JSON parse error because "48h" is not a
+# JSON number. Issue: `jq: error: 48h is not valid JSON text`.
+_parse_ttl() {
+    local input="${1:-}"
+    if [ -z "$input" ]; then
+        echo "scrt4: _parse_ttl: empty TTL" >&2
+        return 1
+    fi
+    # Pure integer → seconds.
+    if [[ "$input" =~ ^[1-9][0-9]*$ ]]; then
+        printf '%s\n' "$input"
+        return 0
+    fi
+    # Number + unit suffix.
+    if [[ "$input" =~ ^([1-9][0-9]*)([smhd])$ ]]; then
+        local n="${BASH_REMATCH[1]}" unit="${BASH_REMATCH[2]}"
+        case "$unit" in
+            s) printf '%s\n' "$n" ;;
+            m) printf '%s\n' "$(( n * 60 ))" ;;
+            h) printf '%s\n' "$(( n * 3600 ))" ;;
+            d) printf '%s\n' "$(( n * 86400 ))" ;;
+        esac
+        return 0
+    fi
+    echo "scrt4: invalid TTL '${input}' — expected integer seconds or N{s,m,h,d} (e.g. 48h, 30m, 2d, 7200)" >&2
+    return 1
+}
+
 # ── WebAuthn flow helpers (ported from v0.1.0 monolith, ISS016) ──────
 #
 # These helpers drive the QR-code + relay polling flow used by cmd_unlock
@@ -841,10 +884,12 @@ CORE COMMANDS:
     status              Check session status
     setup [--agent]     Register a WebAuthn passkey (first-time enrollment)
     unlock [--agent] [ttl] Authenticate and start a session
+                        (ttl: integer seconds or N{s,m,h,d}, e.g. 48h, 30m)
                         (--agent renders the QR in plain ASCII with banner
                          markers so AI coding assistants pass it through
                          unmodified instead of truncating it)
     extend [ttl]        Reset session timer (optionally update TTL)
+                        (ttl: integer seconds or N{s,m,h,d}, e.g. 48h, 30m)
     logout              Lock the session (aliases: lock, clear)
     list [--tags] [--tag T]  List secret names (optionally with tags / filtered)
     add [KEY=value ...] Add secrets (GUI notepad if no args)
@@ -898,7 +943,9 @@ cmd_extend() {
     # even when ttl is null. Sending `{"method":"extend"}` alone fails
     # to deserialize.
     if [ -n "$ttl" ]; then
-        req=$(jq -nc --argjson ttl "$ttl" '{method:"extend",params:{ttl:$ttl}}')
+        local ttl_secs
+        ttl_secs=$(_parse_ttl "$ttl") || return 1
+        req=$(jq -nc --argjson ttl "$ttl_secs" '{method:"extend",params:{ttl:$ttl}}')
     else
         req='{"method":"extend","params":{"ttl":null}}'
     fi
@@ -945,7 +992,10 @@ cmd_unlock() {
         esac
     done
 
-    run_unlock_flow "$ttl"
+    local ttl_secs
+    ttl_secs=$(_parse_ttl "$ttl") || return 1
+
+    run_unlock_flow "$ttl_secs"
 }
 
 # cmd_setup [--cli] — enroll a new WebAuthn credential (passkey).


### PR DESCRIPTION
## Summary

`scrt4 unlock 48h` (or any non-numeric TTL) currently fails with a `jq` error because the value is passed straight to `jq --argjson`, which requires a JSON number:

```
$ scrt4 unlock 48h
jq: error: 48h is not valid JSON text
```

The help string just says `[ttl]` with no format hint, so users reasonably try `48h`, `30m`, `2d`. This PR adds a `_parse_ttl` helper that accepts integer seconds (back-compatible) **or** a N{s,m,h,d} suffix, wires it into `cmd_unlock` and `cmd_extend` before the `jq` call, and updates the help text in both places to document the accepted formats.

## Changes

- `daemon/bin/scrt4-core`:
  - New `_parse_ttl` helper (placed in a small "TTL parsing" section between daemon I/O and the WebAuthn flow helpers, since both `cmd_unlock` and `cmd_extend` need it).
  - `cmd_unlock`: parse the user-supplied ttl through `_parse_ttl` before calling `run_unlock_flow`. Bail with rc=1 on invalid input.
  - `cmd_extend`: parse the user-supplied ttl through `_parse_ttl` before the `jq --argjson` call. Same rc=1 on invalid input.
  - Help text on both commands documents `(ttl: integer seconds or N{s,m,h,d}, e.g. 48h, 30m)`.

No daemon-side changes; the wire format is still an integer-seconds JSON number.

## Test plan

Validated `_parse_ttl` against the patched, built binary. All 10 cases pass:

| Input | rc | Output |
|---|---|---|
| `7200` | 0 | `7200` |
| `48h` | 0 | `172800` |
| `30m` | 0 | `1800` |
| `2d` | 0 | `172800` |
| `3600s` | 0 | `3600` |
| _(empty)_ | 1 | `scrt4: _parse_ttl: empty TTL` |
| `abc` | 1 | `scrt4: invalid TTL 'abc' — expected ...` |
| `0` | 1 | `scrt4: invalid TTL '0' — expected ...` |
| `1.5h` | 1 | `scrt4: invalid TTL '1.5h' — expected ...` |
| `10x` | 1 | `scrt4: invalid TTL '10x' — expected ...` |

- [x] `bash -n` clean on the assembled binary
- [x] `scrt4 help` shows updated unlock/extend help
- [x] `_parse_ttl` accepts back-compat integer-seconds input
- [x] `_parse_ttl` accepts `Nh`/`Nm`/`Nd`/`Ns`
- [x] `_parse_ttl` rejects empty / negative / zero / float / bare-unit / trailing-junk with a clear stderr message instead of a misleading `jq:` error further down the pipe
- [ ] End-to-end: `scrt4 unlock 48h` against a live daemon (will be done by the maintainer; I haven't started a fresh session against my live daemon for this PR run)

## Notes / scope

- I noticed a separate doc/code mismatch in the long-form help block (`scrt4 unlock [ttl]  # … (default 2h)`) — the actual default in `cmd_unlock` is `72000` seconds (= 20h), not 2h. Left it alone to keep this PR scoped to the TTL-parsing bug; happy to fix it in a follow-up if you'd like.
- `unlock_local` (the auto-unlock-from-saved-key path, lines 766/778) hardcodes `7200` and ignores user-supplied ttl. Same — separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)