### PR TITLE
run: execute in the caller's directory, and add --cwd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,10 @@ target/
 # Vercel project link (per-checkout, not source)
 # ----------------------------------------
 .vercel/
+
+# Local AI-assistant working instructions. These are per-developer notes, not
+# project documentation, and must never be published from here.
+CLAUDE.local.md
+**/CLAUDE.local.md
+.claude/
+**/.claude/

--- a/scrt4/daemon/bin/scrt4-core
+++ b/scrt4/daemon/bin/scrt4-core
@@ -804,9 +804,14 @@ _wa_gate() {
 #                 command string with $env[NAME] placeholders intact.
 _run_with_injected_secrets() {
     local cmd="$1"
+    local cwd="${2:-$PWD}"
     local response
     # Daemon protocol: Run takes `command` (not `cmd`). See daemon/src/protocol.rs.
-    response=$(send_request "$(jq -nc --arg c "$cmd" '{method:"run",params:{command:$c}}')" 2>/dev/null || true)
+    #
+    # working_dir matters: the daemon is a long-lived process whose own cwd is
+    # wherever it was started — often / — so without this every relative path
+    # in the command resolves against that instead of the caller's directory.
+    response=$(send_request "$(jq -nc --arg c "$cmd" --arg d "$cwd" '{method:"run",params:{command:$c,working_dir:$d}}')" 2>/dev/null || true)
     local ok
     ok=$(echo "$response" | jq -r '.success // false' 2>/dev/null || echo "false")
     if [ "$ok" != "true" ]; then
@@ -848,7 +853,9 @@ CORE COMMANDS:
     logout              Lock the session (aliases: lock, clear)
     list [--tags] [--tag T]  List secret names (optionally with tags / filtered)
     add [KEY=value ...] Add secrets (GUI notepad if no args)
-    run 'cmd $env[K]'   Run a command with secret injection
+    run [--cwd DIR] 'cmd $env[K]'
+                        Run a command with secret injection. Runs in the
+                        current directory unless --cwd is given.
     view [--cli]        View secrets (GUI default, --cli for terminal)
     rotate              Rotate the vault master key (re-encrypts all secrets)
     share [--all] [NAME ...]     Share secrets via Magic Wormhole
@@ -2492,14 +2499,32 @@ print(json.dumps(secrets), end="")
 # cmd_run 'CMD' — runs a command with $env[NAME] substitution.
 # This is one of the most security-sensitive paths; the substitution
 # itself happens daemon-side (see TCB note on _run_with_injected_secrets).
+# cmd_run [--cwd DIR] 'cmd $env[KEY]'
+#
+# Runs in the caller's directory by default; --cwd overrides it.
 cmd_run() {
     ensure_unlocked || return 1
+    local cwd="$PWD"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --cwd)
+                [ $# -ge 2 ] || { echo "scrt4 run: --cwd needs a directory" >&2; return 1; }
+                cwd="$2"; shift 2 ;;
+            --cwd=*)
+                cwd="${1#--cwd=}"; shift ;;
+            *) break ;;
+        esac
+    done
     if [ $# -eq 0 ]; then
-        echo "Usage: scrt4 run 'cmd \$env[KEY]'" >&2
+        echo "Usage: scrt4 run [--cwd DIR] 'cmd \$env[KEY]'" >&2
+        return 1
+    fi
+    if [ ! -d "$cwd" ]; then
+        echo "scrt4 run: no such directory: $cwd" >&2
         return 1
     fi
     local cmd="$*"
-    _run_with_injected_secrets "$cmd"
+    _run_with_injected_secrets "$cmd" "$cwd"
 }
 
 # cmd_view [--cli] — view secret values.

--- a/scrt4/windows/scrt4/scrt4.psm1
+++ b/scrt4/windows/scrt4/scrt4.psm1
@@ -902,18 +902,38 @@ function Invoke-CmdAdd {
     return 1
 }
 
+# scrt4 run [--cwd DIR] 'cmd $env[KEY]'
+#
+# Runs in the caller's directory by default; --cwd overrides it.
 function Invoke-CmdRun {
     param([string[]]$Rest)
 
     if (-not (Test-Scrt4Unlocked)) { return 1 }
+
+    $cwd = (Get-Location).Path
+    while ($Rest.Count -gt 0) {
+        if ($Rest[0] -eq '--cwd') {
+            if ($Rest.Count -lt 2) { Write-Err 'scrt4 run: --cwd needs a directory'; return 1 }
+            $cwd = $Rest[1]; $Rest = $Rest[2..($Rest.Count - 1)]
+        } elseif ($Rest[0] -like '--cwd=*') {
+            $cwd = $Rest[0].Substring(6); $Rest = @($Rest[1..($Rest.Count - 1)])
+        } else { break }
+    }
     if ($Rest.Count -eq 0) {
-        Write-Err 'Usage: scrt4 run ''cmd $env[KEY]'''
+        Write-Err 'Usage: scrt4 run [--cwd DIR] ''cmd $env[KEY]'''
+        return 1
+    }
+    if (-not (Test-Path -LiteralPath $cwd -PathType Container)) {
+        Write-Err "scrt4 run: no such directory: $cwd"
         return 1
     }
     $cmd = $Rest -join ' '
 
+    # working_dir matters: the daemon is a long-lived process whose own cwd is
+    # wherever it was started, so without this every relative path in the
+    # command resolves against that instead of the caller's directory.
     $resp = $null
-    try { $resp = Send-Scrt4Request @{ method = 'run'; params = @{ command = $cmd } } } catch {
+    try { $resp = Send-Scrt4Request @{ method = 'run'; params = @{ command = $cmd; working_dir = $cwd } } } catch {
         Write-Err "scrt4 run failed: $($_.Exception.Message)"
         return 1
     }
@@ -1327,7 +1347,9 @@ CORE COMMANDS:
     logout              Lock the session (aliases: lock, clear)
     list [--tags] [--tag T]  List secret names (optionally with tags / filtered)
     add [KEY=value ...] Add secrets (GUI notepad if no args)
-    run 'cmd $env[K]'   Run a command with secret injection (cmd.exe syntax)
+    run [--cwd DIR] 'cmd $env[K]'
+                        Run a command with secret injection (cmd.exe syntax).
+                        Runs in the current directory unless --cwd is given.
     view [--cli]        View secrets (GUI default, --cli for terminal)
     backup-vault [--local DIR]   Archive the vault directory (tar.gz)
     backup-key [--save DIR]      Show or save the master key


### PR DESCRIPTION
Closes #33. Thanks @skazazes-work — the diagnosis in that report was exactly right.

The daemon is long-lived and its own working directory is wherever it was
started, commonly `/`. A command sent without one resolved every relative path
against that, which is why `ls data/` listed `/data`.

The interesting part: **the protocol has carried `working_dir` from the start
and the daemon already honours it** — `subprocess.rs` calls `current_dir` when
it is set. No client had ever sent it. So this is only the client half, on both
the bash and PowerShell sides.

Both now send the caller's directory by default and accept `--cwd DIR` to
override, rejecting a directory that does not exist rather than silently
falling back to somewhere else.

### On PATH

This does not change PATH, and that is deliberate. The child still inherits the
daemon's environment, so an activated virtualenv is reachable as
`.venv/bin/python` but not as `python`. Forwarding the caller's PATH changes
which binaries the secrets daemon will execute, which deserves its own decision
rather than riding along with a cwd fix. Tracking separately.

### Verified

Three regression checks cover the default working directory, the `--cwd`
override, and `--cwd` pointing at a directory that does not exist. All three
fail against the unfixed client, reproducing the report, and pass with it.

Also ignores `CLAUDE.local.md` at any depth, and `.claude/` at the root — the
subtree already ignored it, the root did not. Those are per-developer working
notes rather than project documentation.

> Stacked on #38, which touches the same two files. Retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTJgiGj5jV473VoBgTQATL
