### PR TITLE
Build Linux and macOS binaries in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,55 @@ jobs:
           path: artifacts/scrt4
           if-no-files-found: error
 
+  # Run the built artifacts on the platform they were built for. A command
+  # whose handler no longer exists still parses, still registers, and still
+  # reviews clean — it only fails when someone runs it, which is how `lock`
+  # once shipped as a silent no-op. This is the gate that catches that.
+  #
+  # Only the native pair per runner: an aarch64-linux binary cannot execute
+  # on the x86_64 runner, so cross-built artifacts are checked by the build
+  # succeeding, not by running them.
+  verify:
+    name: verify (${{ matrix.os_label }})
+    needs: [build-daemon, build-cli]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_label: linux
+            arch: x86_64
+            runner: ubuntu-latest
+          - os_label: darwin
+            arch: aarch64
+            runner: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Download daemon
+        uses: actions/download-artifact@v4
+        with:
+          name: scrt4-daemon-${{ matrix.os_label }}-${{ matrix.arch }}
+          path: art
+
+      - name: Download CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: scrt4-cli
+          path: art
+
+      - name: Check the artifacts
+        run: |
+          bash scrt4/scripts/check-release-artifacts.sh \
+            art/scrt4-daemon-${{ matrix.os_label }}-${{ matrix.arch }} \
+            art/scrt4
+
   bundle:
     name: bundle + checksums
-    needs: [build-daemon, build-cli]
+    needs: [build-daemon, build-cli, verify]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,169 @@
+name: Release native binaries
+
+# Builds the scrt4-daemon Rust binary for each supported OS/arch pair plus the
+# assembled bash CLI, and emits them as one workflow artifact with a
+# SHA256SUMS file the native installer verifies against.
+#
+# It deliberately does NOT create a GitHub Release. Distribution is served
+# from the llmsecrets domain; this repository is source and CI only. The
+# bundle produced here is what gets published to that host.
+#
+# macOS is the reason this exists at all: a darwin binary cannot be
+# cross-compiled from the machines we build Windows on, so it needs a macOS
+# runner.
+#
+# Artifacts:
+#   scrt4-daemon-linux-x86_64
+#   scrt4-daemon-linux-aarch64
+#   scrt4-daemon-darwin-aarch64   Apple Silicon; Intel Macs run it under Rosetta 2
+#   scrt4                         the core-only bash CLI
+#   SHA256SUMS
+#
+# Windows is released separately as a bundled zip and is not built here.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re)build artifacts for'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-daemon:
+    name: daemon (${{ matrix.os_label }}/${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_label: linux
+            arch: x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            cross: false
+          - os_label: linux
+            arch: aarch64
+            runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            cross: true
+          - os_label: darwin
+            arch: aarch64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+            cross: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation deps (linux/aarch64)
+        if: matrix.cross == true
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          mkdir -p scrt4/daemon/.cargo
+          cat >> scrt4/daemon/.cargo/config.toml <<'EOF'
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+          EOF
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            scrt4/daemon/target
+          key: cargo-${{ matrix.target }}-${{ hashFiles('scrt4/daemon/Cargo.lock') }}
+
+      - name: Build daemon (release, ${{ matrix.target }})
+        working-directory: scrt4/daemon
+        run: cargo build --release --locked --bin scrt4-daemon --target ${{ matrix.target }}
+
+      - name: Rename artifact
+        run: |
+          mkdir -p artifacts
+          cp scrt4/daemon/target/${{ matrix.target }}/release/scrt4-daemon \
+             artifacts/scrt4-daemon-${{ matrix.os_label }}-${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scrt4-daemon-${{ matrix.os_label }}-${{ matrix.arch }}
+          path: artifacts/scrt4-daemon-${{ matrix.os_label }}-${{ matrix.arch }}
+          if-no-files-found: error
+
+  build-cli:
+    name: cli (core-only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Assemble the scrt4 CLI
+        # core-only is the distribution this repository ships: the vault core
+        # with no modules. Stamping SCRT4_VERSION from the tag keeps
+        # `scrt4 --version` from reporting the in-repo -dev placeholder.
+        env:
+          SCRT4_VERSION: ${{ github.event.inputs.tag || github.ref_name }}
+        working-directory: scrt4
+        run: |
+          mkdir -p ../artifacts
+          bash scripts/build-scrt4.sh core-only ../artifacts/scrt4
+          bash -n ../artifacts/scrt4
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scrt4-cli
+          path: artifacts/scrt4
+          if-no-files-found: error
+
+  bundle:
+    name: bundle + checksums
+    needs: [build-daemon, build-cli]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Flatten and checksum
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          # download-artifact nests each artifact in a directory of its own
+          # name, so flatten before hashing — otherwise SHA256SUMS records
+          # paths the installer will never look for.
+          find dist -type f -exec cp {} out/ \;
+          chmod +x out/scrt4-daemon-* out/scrt4
+          cd out
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      # Distribution is served from the llmsecrets domain, not from here.
+      # This job's only output is a verified artifact set to publish there;
+      # it deliberately does not create a GitHub Release.
+      - name: Upload the release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: scrt4-${{ github.event.inputs.tag || github.ref_name }}-unix
+          path: out/
+          if-no-files-found: error

--- a/scrt4/scripts/check-release-artifacts.sh
+++ b/scrt4/scripts/check-release-artifacts.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# check-release-artifacts.sh DAEMON CLI
+#
+# Verifies that a built daemon and CLI are fit to publish. Run against the
+# artifacts themselves, on the platform they were built for.
+#
+# It answers one question the build alone cannot: does every command the CLI
+# can issue reach a handler that exists? A command whose handler was removed
+# still parses, still registers, and still looks fine in review — it only
+# fails when someone runs it. That shipped once: `lock`, `clear` and `logout`
+# all sent a method the protocol never defined, so locking the vault was a
+# silent no-op.
+#
+# Unlock needs a hardware authenticator, so this deliberately does not test
+# the authenticated paths. It tests routing, which is what breaks silently.
+set -euo pipefail
+
+DAEMON="${1:?usage: check-release-artifacts.sh DAEMON CLI}"
+CLI="${2:?usage: check-release-artifacts.sh DAEMON CLI}"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/scrt4-check.XXXXXX")
+export XDG_RUNTIME_DIR="$WORK"
+SOCKET="$WORK/scrt4.sock"
+FAILED=0
+
+cleanup() {
+    [ -n "${DAEMON_PID:-}" ] && kill "$DAEMON_PID" 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "== artifacts"
+chmod +x "$DAEMON" "$CLI"
+file "$DAEMON" | sed 's/^/   /'
+bash -n "$CLI" && echo "   CLI syntax OK"
+
+echo "== daemon starts"
+HOME="$WORK" "$DAEMON" >"$WORK/daemon.log" 2>&1 &
+DAEMON_PID=$!
+for _ in $(seq 1 50); do
+    [ -S "$SOCKET" ] && break
+    sleep 0.2
+done
+if [ ! -S "$SOCKET" ]; then
+    echo "   FAIL: no socket at $SOCKET after 10s"
+    sed 's/^/   | /' "$WORK/daemon.log"
+    exit 1
+fi
+kill -0 "$DAEMON_PID" 2>/dev/null || { echo "   FAIL: daemon exited"; exit 1; }
+echo "   listening at $SOCKET"
+
+# One round-trip per method, straight to the socket. Going through the CLI
+# would not work here: for most commands it refuses before it sends anything,
+# so the RPC that matters is never exercised.
+send() {
+    python3 - "$SOCKET" "$1" <<'PY'
+import socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(10)
+s.connect(sys.argv[1])
+s.sendall((sys.argv[2] + "\n").encode())
+buf = b""
+while b"\n" not in buf:
+    chunk = s.recv(65536)
+    if not chunk:
+        break
+    buf += chunk
+print(buf.decode(errors="replace").strip())
+PY
+}
+
+echo "== status responds"
+resp=$(send '{"method":"status"}')
+case "$resp" in
+    *'"success":true'*) echo "   $resp" ;;
+    *) echo "   FAIL: $resp"; FAILED=1 ;;
+esac
+
+echo "== a method that does not exist is rejected"
+# Proves the assertion below can actually fail. Without this the whole check
+# passes vacuously if the error text ever changes.
+resp=$(send '{"method":"definitely_not_a_method"}')
+case "$resp" in
+    *'Invalid request'*) echo "   rejected as expected" ;;
+    *) echo "   FAIL: unknown method was not rejected: $resp"; FAILED=1 ;;
+esac
+
+echo "== every method the CLI can send is routable"
+# Two spellings, and missing the second one makes this check pass vacuously:
+# requests written as raw JSON use "method":"x", but those built through jq
+# use bare object keys — method:"x". Roughly half the surface is the jq form.
+METHODS=$(grep -oE '"?method"?[[:space:]]*:[[:space:]]*"[a-z_]+"' "$CLI" \
+    | sed 's/.*"\([a-z_]*\)"$/\1/' | sort -u)
+COUNT=$(printf '%s\n' "$METHODS" | grep -c . || true)
+[ "$COUNT" -ge 15 ] || {
+    echo "   FAIL: only $COUNT methods found in the CLI — extraction is wrong,"
+    echo "         not the CLI. A real client sends more than that."
+    exit 1
+}
+for m in $METHODS; do
+    resp=$(send "{\"method\":\"$m\"}")
+    case "$resp" in
+        *'Invalid request'*)
+            # Distinguish "no such method" from "wrong params for a real
+            # method" — only the first is a broken command.
+            case "$resp" in
+                *'unknown variant'*)
+                    printf '   %-26s UNROUTABLE -- no handler\n' "$m"; FAILED=1 ;;
+                *)
+                    printf '   %-26s ok (needs params)\n' "$m" ;;
+            esac ;;
+        *) printf '   %-26s ok\n' "$m" ;;
+    esac
+done
+
+echo
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAILED"
+    exit 1
+fi
+echo "RESULT: PASS -- $COUNT methods, all routable"


### PR DESCRIPTION
macOS users are still installing an April build. `install.llmsecrets.com/releases/latest.txt` returns `v0.2.14-community`, so the one-liner on the site and in the docs does not deliver the current release — which is why #33 had to be reopened.

The cause is mechanical: **darwin does not cross-compile from the machines the Windows release is cut on.** There is no macOS hardware in the loop, so there has never been a macOS build to publish. This adds the runner that closes that.

### What it builds

| target | runner |
|---|---|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` |
| `aarch64-unknown-linux-gnu` | `ubuntu-latest` (cross) |
| `aarch64-apple-darwin` | `macos-latest` |

Plus the `core-only` bash CLI, with `SCRT4_VERSION` stamped from the tag so `scrt4 --version` reports the release rather than the in-repo `-dev` placeholder. Output is one artifact with `SHA256SUMS` over the set.

### It does not create a GitHub Release

Deliberate, and the reason `permissions:` is `contents: read`. Distribution is served from the llmsecrets domain; this repository stays source and CI only. The bundle here is the *input* to that publish, not the published thing.

The filenames match what the native installer already fetches — `scrt4-daemon-<os>-<arch>`, `scrt4`, `SHA256SUMS` — so nothing on the install side needs to change.

### Checks

- YAML parses; the matrix resolves to the three targets above.
- The CLI assembly step was run locally against this tree: builds a 2841-line client, stamps `VERSION="0.4.0"` from the tag, `bash -n` clean.
- Paths adjusted for this repository's layout (`scrt4/daemon`, `scrt4/scripts`), which differs from where this workflow originally lived.
- Sanitization gate clean.

### After merge

Dispatch needs the workflow on the default branch, so this has to land before it can run at all. Then it builds against `v0.4.0` and the artifacts get published to the install host with `latest.txt` flipped — at which point #33 can close on the reporter's own platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTJgiGj5jV473VoBgTQATL