### PR TITLE
Build Linux against an older glibc, and assert the floor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # ubuntu-22.04, deliberately, not ubuntu-latest. A binary links
+          # against the glibc it was built on and refuses to start on
+          # anything older, so building on the newest runner silently drops
+          # every distro that is not equally new. 22.04 sets the floor at
+          # glibc 2.35, which covers Ubuntu 22.04+, Debian 12+ and RHEL 9+.
           - os_label: linux
             arch: x86_64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             cross: false
           - os_label: linux
             arch: aarch64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             cross: true
           - os_label: darwin
@@ -203,6 +208,36 @@ jobs:
           cd out
           sha256sum * > SHA256SUMS
           cat SHA256SUMS
+
+      # A Linux binary refuses to start on any glibc older than the one it was
+      # built against, and the failure is a crash loop at install time, not a
+      # build error. Running it in CI does not catch this: the runner that
+      # verifies is as new as the runner that built, so the check passes and
+      # the user's machine is what discovers the problem.
+      #
+      # v0.4.1 shipped needing GLIBC_2.39 and crash-looped on Ubuntu 22.04.
+      # This reads the required symbol versions straight out of the ELF, so it
+      # holds regardless of which runner it happens to execute on.
+      - name: Enforce the glibc floor
+        run: |
+          set -euo pipefail
+          FLOOR_MAJOR=2
+          FLOOR_MINOR=35
+          fail=0
+          for f in out/scrt4-daemon-linux-*; do
+            # grep -a rather than strings: no binutils dependency, and the
+            # symbol sits inside a longer line, so this must not be anchored.
+            max=$(LC_ALL=C grep -aoE 'GLIBC_2\.[0-9]+' "$f" | sort -uV | tail -1)
+            [ -n "$max" ] || { echo "$f: no GLIBC symbols found"; fail=1; continue; }
+            minor=${max#GLIBC_2.}
+            if [ "$minor" -gt "$FLOOR_MINOR" ]; then
+              echo "FAIL $f requires $max, floor is GLIBC_${FLOOR_MAJOR}.${FLOOR_MINOR}"
+              fail=1
+            else
+              echo "ok   $(basename "$f") requires $max"
+            fi
+          done
+          exit $fail
 
       # Distribution is served from the llmsecrets domain, not from here.
       # This job's only output is a verified artifact set to publish there;


### PR DESCRIPTION
**v0.4.1 does not run on Ubuntu 22.04.** Found by installing it from the real one-liner on a 22.04 box rather than trusting the green check.

```
scrt4-daemon: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
scrt4-daemon.service: Scheduled restart job, restart counter is at 14.
```

The daemon crash-looped every three seconds. The CLI reported only `daemon socket not found` — nothing anywhere pointed at the cause.

### Why CI said it was fine

Because it could not have said anything else. `verify` runs on a runner as new as the one that built, so the binary always finds the glibc it was linked against. The check was tautological — it proved the binary runs on the machine that produced it, which is never in doubt.

That is the part worth fixing, more than the build flag.

### Two changes

**Linux builds move to `ubuntu-22.04`.** A binary refuses to start on any glibc older than the one it was built against, so building on `ubuntu-latest` silently drops every distro that is not equally new. This puts the floor at glibc 2.35 — Ubuntu 22.04+, Debian 12+, RHEL 9+ — rather than tracking whatever the newest runner happens to be.

**`bundle` now asserts the floor** by reading the required symbol versions out of the ELF. That is independent of the runner, so it cannot go tautological again, and it covers the cross-built aarch64 binary that `verify` never executes.

### On the check itself

The first version used `strings` and an anchored pattern. Both were wrong — `strings` is not always present, and the symbol sits inside a longer line — so it reported `no GLIBC symbols found` for binaries that plainly had them. It failed safe, but it would have blocked every release for the wrong reason. It now uses `grep -a` unanchored, tested against the actual v0.4.1 artifacts, where it correctly reports `GLIBC_2.39` and fails.

### Follow-up, not in this PR

The installer prints `native-default install (TCB core + encrypt-folder + import-env + cloud-crypt)` and tells the user to run `scrt4 quickstart`. None of those exist in this build — `scrt4 quickstart` returns `Unknown command`. That script is served from elsewhere and needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTJgiGj5jV473VoBgTQATL