### PR TITLE
macOS/Linux: setup --local and unlock --local (platform passkeys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Linux, Windows, and WSL.
 
 ---
 
-## 🎉 Five weekly active users — and we'd like one of you to be a maintainer for macOS
+## 🎉 Five weekly active users — and we need a macOS tester (ten minutes) or maintainer
 
 That is a small number and we are pleased with it. Five people unlocked a
 vault in each of the last several weeks; one of them is the maintainer, and
@@ -32,22 +32,44 @@ biometric. Windows users can run `scrt4 setup --local` and unlock with
 Windows Hello. On a Mac you reach for your phone, every single time. The
 people getting the most out of this are the ones with the most friction.
 
-**We would like one of you to own that, as the macOS maintainer.** The
-daemon already implements the flow — `setup_local` answers on every platform
-— so this is a client command and a browser ceremony, not a native
-integration. What it needs is somebody with a Mac to build it and confirm it
-works, because nobody on this side can test Touch ID.
+**The code for it is already written.** The daemon implements the flow on
+every platform, the client commands exist, and Chrome has been confirmed to
+negotiate the PRF extension the design depends on. What is missing is a
+fingerprint: nobody on this side owns a Mac, so nothing has ever been put in
+front of a real Touch ID sensor.
 
-👉 **[#54 — macOS Touch ID / platform passkey support](https://github.com/llmsecrets/llm-secrets/issues/54)**
+So there are two ways to help, and the first one is small:
 
-No prior knowledge of the codebase is assumed; the issue explains what is
-already built and what is left.
+**🧪 macOS tester — about ten minutes, no code.** Run three commands and tell
+us what happened. That is the whole job, and right now it is the only thing
+standing between this and shipping.
+
+```bash
+scrt4 unlock            # your phone, as usual
+scrt4 setup --local     # Chrome opens — register with Touch ID
+scrt4 unlock --local    # should open the vault with no phone at all
+```
+
+Any outcome is useful, including a failure — a clear report that it does not
+work is worth as much to us as one that says it does, and it saves the next
+person the same afternoon. It cannot damage anything: a failed enrolment
+writes nothing and leaves your phone unlock exactly as it was.
+
+**🔧 macOS maintainer — if it needs fixing, or you want to own the platform.**
+If the test surfaces something, or you would like macOS to have someone
+looking after it properly, that is the role. It is a bash client and a
+browser ceremony, not a native integration — no Swift, no Xcode, no Apple
+developer account.
+
+👉 **[#54 — confirm Touch ID unlock](https://github.com/llmsecrets/llm-secrets/issues/54)** —
+the commands, what is already verified, and what is left.
+
+No prior knowledge of the codebase is assumed for either role.
 
 **What contributors get.** Not everything we build ships publicly — the
-public distribution is the vault core, and there is more behind it. People
-who maintain a platform get access to that work. It is the only way we have
-to say thank you properly, and it is worth more than a mention in a
-changelog.
+public distribution is the vault core, and there is more behind it. Testers
+and maintainers both get access to that work. It is the only way we have to
+say thank you properly, and it is worth more than a mention in a changelog.
 
 ### On the numbers above, and what we can actually see
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,60 @@ Linux, Windows, and WSL.
 
 ---
 
+## 🎉 Five weekly active users — and we'd like one of you to be a maintainer for macOS
+
+That is a small number and we are pleased with it. Five people unlocked a
+vault in each of the last several weeks; one of them is the maintainer, and
+the other four found this on their own and kept using it.
+
+Here is the interesting part: **every one of those four is on a Mac.**
+
+And macOS is the one platform where scrt4 cannot yet use the laptop's own
+biometric. Windows users can run `scrt4 setup --local` and unlock with
+Windows Hello. On a Mac you reach for your phone, every single time. The
+people getting the most out of this are the ones with the most friction.
+
+**We would like one of you to own that, as the macOS maintainer.** The
+daemon already implements the flow — `setup_local` answers on every platform
+— so this is a client command and a browser ceremony, not a native
+integration. What it needs is somebody with a Mac to build it and confirm it
+works, because nobody on this side can test Touch ID.
+
+👉 **[#52 — macOS Touch ID / platform passkey support](https://github.com/llmsecrets/llm-secrets/issues/52)**
+
+No prior knowledge of the codebase is assumed; the issue explains what is
+already built and what is left.
+
+**What contributors get.** Not everything we build ships publicly — the
+public distribution is the vault core, and there is more behind it. People
+who maintain a platform get access to that work. It is the only way we have
+to say thank you properly, and it is worth more than a mention in a
+changelog.
+
+### On the numbers above, and what we can actually see
+
+We know the operating system split because a web server writes a user-agent
+string to a log. That is the whole extent of it, and we look at it for one
+reason: to find out where the product is worst for the people using it.
+Finding out that our most regular users are the ones with the clunkiest
+unlock is exactly the sort of thing we want to know.
+
+For the avoidance of doubt about a tool that holds your secrets:
+
+- **There are no accounts.** No email, no sign-up, nothing to identify you.
+- **The client sends no telemetry.** Nothing phones home about your usage.
+- **The relay cannot read what it relays** — payloads are encrypted
+  end-to-end between your phone and your computer.
+- What remains is an ordinary HTTP access log on the machine that brokers
+  the unlock: an address, a timestamp, a user-agent.
+
+*How the count was derived: distinct networks that completed a relay unlock,
+grouped per ISO week, addresses reduced to a /24. A network is not strictly
+a person — the same user on mobile data and at home looks like two — so read
+it as an honest order of magnitude rather than a headcount.*
+
+---
+
 ## The Problem
 
 When Claude Code reads your `.env` file, your API keys, database passwords, and private keys land in the AI's context window — and every prompt cache, log line, and error report that follows.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ daemon already implements the flow — `setup_local` answers on every platform
 integration. What it needs is somebody with a Mac to build it and confirm it
 works, because nobody on this side can test Touch ID.
 
-👉 **[#52 — macOS Touch ID / platform passkey support](https://github.com/llmsecrets/llm-secrets/issues/52)**
+👉 **[#54 — macOS Touch ID / platform passkey support](https://github.com/llmsecrets/llm-secrets/issues/54)**
 
 No prior knowledge of the codebase is assumed; the issue explains what is
 already built and what is left.
@@ -139,7 +139,7 @@ on disk:
 curl -fsSL https://install.llmsecrets.com/native | sh
 ```
 
-Linux (`x86_64`, `aarch64`) and macOS (Apple Silicon). `SCRT4_VERSION=v0.4.3`
+Linux (`x86_64`, `aarch64`) and macOS (Apple Silicon). `SCRT4_VERSION=v0.4.5`
 pins a specific release if you want one.
 
 Afterwards, `scrt4 upgrade` installs later releases — checksum-verified the
@@ -153,6 +153,7 @@ tag list here is source history; the channel above is what ships.
 
 ```bash
 scrt4 setup                        # one-time FIDO2 enrollment
+scrt4 setup --local                # add this device's own biometric (Windows today)
 scrt4 unlock                       # default 20-hour session
 scrt4 add API_KEY=sk-live-...      # add a secret
 scrt4 list                         # see names (never values)

--- a/scrt4/daemon/bin/scrt4-core
+++ b/scrt4/daemon/bin/scrt4-core
@@ -746,6 +746,94 @@ ensure_unlocked() {
     return 1
 }
 
+# ── platform passkey (Touch ID / Windows Hello) ───────────────────────
+#
+# The daemon wraps the EXISTING master key with the PRF output of a
+# localhost-rpId credential, so what lands on disk is only openable by a
+# live biometric ceremony. That is why setup requires an unlocked session:
+# there has to be a master key in memory to wrap.
+
+# run_setup_local_flow — enrol this machine's authenticator.
+run_setup_local_flow() {
+    local start
+    start=$(send_request '{"method":"setup_local"}' 2>/dev/null || true)
+    if [ "$(echo "$start" | jq -r '.success // false' 2>/dev/null)" != "true" ]; then
+        local err
+        err=$(echo "$start" | jq -r '.error // "unknown error"' 2>/dev/null)
+        echo -e "${RED}setup --local failed: ${err}${NC}" >&2
+        case "$err" in
+            *"ession"*|*"master key"*)
+                echo -e "${YELLOW}This adds a second way to open a vault that already exists,${NC}" >&2
+                echo -e "${YELLOW}so unlock first with your phone: ${NC}scrt4 unlock" >&2 ;;
+        esac
+        return 1
+    fi
+
+    local url
+    url=$(echo "$start" | jq -r '.data.url // empty' 2>/dev/null)
+    if [ -z "$url" ]; then
+        echo -e "${RED}setup --local failed: daemon returned no URL.${NC}" >&2
+        return 1
+    fi
+
+    echo -e "${CYAN}Registering this device's passkey...${NC}" >&2
+    open_browser "$url"
+    echo -e "  ${CYAN}URL:${NC} ${url}" >&2
+    echo -e "  Register a passkey in the browser window (Touch ID, Windows Hello)." >&2
+    echo "" >&2
+    echo -ne "  ${CYAN}Waiting for registration...${NC}" >&2
+
+    local done_resp
+    done_resp=$(send_request '{"method":"setup_local_complete"}' 180 2>/dev/null || true)
+    echo "" >&2
+    if [ "$(echo "$done_resp" | jq -r '.success // false' 2>/dev/null)" = "true" ]; then
+        echo -e "${GREEN}Device passkey registered.${NC}" >&2
+        echo -e "${GREEN}You can now unlock with: ${NC}scrt4 unlock --local" >&2
+        return 0
+    fi
+    echo -e "${RED}setup --local failed: $(echo "$done_resp" | jq -r '.error // "unknown"')${NC}" >&2
+    return 1
+}
+
+# run_unlock_local_flow [ttl] — unlock using this machine's authenticator,
+# with no phone and no relay. Same ceremony as _wa_gate phase 1.
+run_unlock_local_flow() {
+    local ttl="${1:-72000}"
+    local start
+    start=$(send_request "$(jq -nc --argjson t "$ttl" '{method:"unlock_local",params:{ttl:$t}}')" 2>/dev/null || true)
+    if [ "$(echo "$start" | jq -r '.success // false' 2>/dev/null)" != "true" ]; then
+        local err
+        err=$(echo "$start" | jq -r '.error // "unknown error"' 2>/dev/null)
+        echo -e "${RED}unlock --local failed: ${err}${NC}" >&2
+        echo -e "${YELLOW}If this device has no passkey yet: ${NC}scrt4 unlock && scrt4 setup --local" >&2
+        return 1
+    fi
+
+    local url
+    url=$(echo "$start" | jq -r '.data.url // empty' 2>/dev/null)
+    if [ -z "$url" ]; then
+        echo -e "${RED}unlock --local failed: daemon returned no URL.${NC}" >&2
+        return 1
+    fi
+
+    echo -e "${CYAN}Opening browser for authentication...${NC}" >&2
+    open_browser "$url"
+    echo -e "  ${CYAN}URL:${NC} ${url}" >&2
+    echo -e "  Authenticate in the browser window." >&2
+    echo "" >&2
+    echo -ne "  ${CYAN}Waiting for authentication...${NC}" >&2
+
+    local done_resp
+    done_resp=$(send_request "$(jq -nc --argjson t "$ttl" '{method:"unlock_local_complete",params:{ttl:$t}}')" 180 2>/dev/null || true)
+    echo "" >&2
+    if [ "$(echo "$done_resp" | jq -r '.success // false' 2>/dev/null)" = "true" ]; then
+        echo -e "${GREEN}Session active.${NC}" >&2
+        return 0
+    fi
+    echo -e "${RED}unlock --local failed: $(echo "$done_resp" | jq -r '.error // "unknown"')${NC}" >&2
+    return 1
+}
+
 # TCB: webauthn step-up gate
 # Verifies: sensitive operations trigger a fresh WebAuthn challenge
 #           regardless of session state. The session token alone is
@@ -845,7 +933,10 @@ CORE COMMANDS:
     daemon              Start scrt4-daemon in the foreground
     status              Check session status
     setup [--agent]     Register a WebAuthn passkey (first-time enrollment)
-    unlock [--agent] [ttl] Authenticate and start a session
+    setup --local       Add this device's own passkey (Touch ID / Windows
+                        Hello) so unlocking needs no phone. Unlock first.
+    unlock [--local] [--agent] [ttl] Authenticate and start a session
+                        (--local uses this device's own passkey)
                         (--agent renders the QR in plain ASCII with banner
                          markers so AI coding assistants pass it through
                          unmodified instead of truncating it)
@@ -942,14 +1033,21 @@ cmd_status() {
 # scans a QR on their phone, the phone authenticates with a passkey,
 # and the encrypted PRF payload comes back through the relay.
 cmd_unlock() {
+    local _unlock_local=false
     local ttl="72000"
     while [ $# -gt 0 ]; do
         case "$1" in
+            --local)     _unlock_local=true; shift ;;
             --agent)     AGENT_MODE=true; FORCE_CLI=true; shift ;;
             --cli|agent) FORCE_CLI=true; shift ;;
             *)           ttl="$1"; shift ;;
         esac
     done
+
+    if [ "$_unlock_local" = true ]; then
+        run_unlock_local_flow "${ttl:-72000}"
+        return $?
+    fi
 
     run_unlock_flow "$ttl"
 }
@@ -961,13 +1059,20 @@ cmd_unlock() {
 # them — we print a loud warning and require typed "YES" confirmation
 # before proceeding. Ported from the v0.1.0 monolith.
 cmd_setup() {
+    local use_local=false
     while [ $# -gt 0 ]; do
         case "$1" in
+            --local)     use_local=true; shift ;;
             --agent)     AGENT_MODE=true; FORCE_CLI=true; shift ;;
             --cli|agent) FORCE_CLI=true; shift ;;
             *)           shift ;;
         esac
     done
+
+    if [ "$use_local" = true ]; then
+        run_setup_local_flow
+        return $?
+    fi
 
     # Warn if existing secrets would be wiped. Registration generates
     # a new master key, and the old vault becomes unrecoverable without

--- a/scrt4/daemon/bin/scrt4-core
+++ b/scrt4/daemon/bin/scrt4-core
@@ -746,6 +746,46 @@ ensure_unlocked() {
     return 1
 }
 
+# open_ceremony_browser URL — open the platform-passkey ceremony, in Chrome
+# where we can find it.
+#
+# Deliberately narrower than open_browser. The relay flow is a QR code and
+# works anywhere; this ceremony needs an authenticator that exposes the
+# WebAuthn PRF extension, and on macOS "the platform authenticator" is not
+# one thing — Safari reaches iCloud Keychain, Chrome has its own
+# profile-bound authenticator behind Touch ID, and their PRF support differs
+# by version. Chrome's is the one we target.
+#
+# Falls back to the default browser rather than failing: a user with no
+# Chrome should still get a shot at it, and the URL is always printed so
+# they can paste it wherever they like.
+open_ceremony_browser() {
+    local url="$1"
+    local os
+    os=$(uname -s 2>/dev/null || echo unknown)
+
+    if [ "$os" = "Darwin" ]; then
+        for app in "Google Chrome" "Chromium" "Microsoft Edge" "Brave Browser"; do
+            if open -a "$app" "$url" >/dev/null 2>&1; then
+                echo -e "  ${CYAN}Opened in ${app}.${NC}" >&2
+                return 0
+            fi
+        done
+    else
+        for bin in google-chrome google-chrome-stable chromium chromium-browser microsoft-edge brave-browser; do
+            if command -v "$bin" >/dev/null 2>&1; then
+                "$bin" "$url" >/dev/null 2>&1 &
+                echo -e "  ${CYAN}Opened in ${bin}.${NC}" >&2
+                return 0
+            fi
+        done
+    fi
+
+    echo -e "  ${YELLOW}Chrome not found — using your default browser.${NC}" >&2
+    echo -e "  ${YELLOW}If registration fails, try again in Chrome.${NC}" >&2
+    open_browser "$url"
+}
+
 # ── platform passkey (Touch ID / Windows Hello) ───────────────────────
 #
 # The daemon wraps the EXISTING master key with the PRF output of a
@@ -777,9 +817,10 @@ run_setup_local_flow() {
     fi
 
     echo -e "${CYAN}Registering this device's passkey...${NC}" >&2
-    open_browser "$url"
+    open_ceremony_browser "$url"
     echo -e "  ${CYAN}URL:${NC} ${url}" >&2
     echo -e "  Register a passkey in the browser window (Touch ID, Windows Hello)." >&2
+    echo -e "  ${YELLOW}Chrome is the tested browser for this step.${NC}" >&2
     echo "" >&2
     echo -ne "  ${CYAN}Waiting for registration...${NC}" >&2
 
@@ -817,7 +858,7 @@ run_unlock_local_flow() {
     fi
 
     echo -e "${CYAN}Opening browser for authentication...${NC}" >&2
-    open_browser "$url"
+    open_ceremony_browser "$url"
     echo -e "  ${CYAN}URL:${NC} ${url}" >&2
     echo -e "  Authenticate in the browser window." >&2
     echo "" >&2


### PR DESCRIPTION
**Draft** — the code is written and verified as far as a machine with no fingerprint sensor allows. It stays draft until someone confirms it on a Mac (#54).

Two files: the Unix client, and the README section announcing five weekly active users and asking one of the four Mac users to maintain the platform.

## The commands

`scrt4 setup --local` enrols this machine's own authenticator; `scrt4 unlock --local` uses it, with no phone and no relay.

```bash
run_setup_local_flow() {
    local start
    start=$(send_request '{"method":"setup_local"}' 2>/dev/null || true)
    if [ "$(echo "$start" | jq -r '.success // false')" != "true" ]; then
        local err; err=$(echo "$start" | jq -r '.error // "unknown error"')
        echo -e "${RED}setup --local failed: ${err}${NC}" >&2
        case "$err" in
            *"ession"*|*"master key"*)
                echo -e "${YELLOW}This adds a second way to open a vault that already exists,${NC}" >&2
                echo -e "${YELLOW}so unlock first with your phone: ${NC}scrt4 unlock" ;;
        esac
        return 1
    fi
    local url; url=$(echo "$start" | jq -r '.data.url // empty')
    open_ceremony_browser "$url"
    send_request '{"method":"setup_local_complete"}' 180
}
```

The error handling is the part worth reviewing. `setup --local` cannot work without an unlocked session, because it wraps a master key that must already be in memory. Rather than surface that as a bare protocol error, it explains the ordering and names the command to run first.

## Why Chrome specifically

```bash
open_ceremony_browser() {
    local url="$1"
    if [ "$(uname -s)" = "Darwin" ]; then
        for app in "Google Chrome" "Chromium" "Microsoft Edge" "Brave Browser"; do
            open -a "$app" "$url" >/dev/null 2>&1 && return 0
        done
    fi
    # ...Linux equivalents, then fall back to the default browser
}
```

On macOS "the platform authenticator" is not one thing. Safari reaches iCloud Keychain passkeys; Chrome has its own profile-bound authenticator behind Touch ID. Their PRF support differs by version, so targeting Chrome collapses several unknowns into one — and every Mac client seen on the relay in the last month was already Chrome.

Scoped deliberately: `open_browser` is untouched and still used for the relay flow, which works in any browser.

## Nothing platform-specific was needed

No Rust, no Swift, no entitlements. `localhost.rs` and the `setup_local` handlers contain **zero** `cfg(windows)` — the ceremony is a localhost browser flow the daemon already serves everywhere. Windows was never special-cased; it just had a client command and Unix did not.

Both flows mirror `_wa_gate`, which runs the same ceremony a few lines below for step-up verification: same request shapes, same 180s timeout, same helpers.

## Verified

On Linux, against a running daemon:

- both commands registered and documented in `help`
- all four `*_local` RPCs routable
- correct refusals while locked, with actionable messages
- `setup_local` returns a ceremony URL that serves a real WebAuthn page requesting the `prf` extension

Then driven with a **Chrome virtual authenticator** configured as a platform authenticator with PRF:

```js
await cdp.send('WebAuthn.addVirtualAuthenticator', {
  options: { protocol: 'ctap2', transport: 'internal',
             hasResidentKey: true, hasUserVerification: true,
             hasPrf: true, isUserVerified: true,
             automaticPresenceSimulation: true },
});
```

```
page says: Registered! You can close this tab.
credentials on the authenticator: 1

setup_local_complete = {"success":true}
unlock_local         = {"success":true,"data":{"url":"http://localhost:9474"}}
```

**Chrome negotiated PRF against a platform authenticator and the daemon accepted the output and wrapped the master key.** The credential persisted.

Browser selection is verified separately against fake browsers on `PATH`: Chrome wins when present, Chromium and Edge are used when it is not, default browser when none are.

## Not verified

A virtual authenticator is not a fingerprint. Real Touch ID hardware, and the unwrap half — enrol then unlock with no phone — are what #54 asks a Mac owner to confirm.

Safe to try regardless: every failure in `handle_setup_local_complete` returns before any write, so a failed enrolment leaves an existing phone unlock untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTJgiGj5jV473VoBgTQATL