### PR TITLE
README: tell testers how to install the build that has the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,27 @@ So there are two ways to help, and the first one is small:
 us what happened. That is the whole job, and right now it is the only thing
 standing between this and shipping.
 
+First get a build with the commands in it — they landed in **v0.4.6**:
+
+```bash
+# new install
+curl -fsSL https://install.llmsecrets.com/native | sh
+
+# already have scrt4?
+scrt4 upgrade
+```
+
+Either way, `scrt4 --version` should say `0.4.6` or later. Then:
+
 ```bash
 scrt4 unlock            # your phone, as usual
 scrt4 setup --local     # Chrome opens — register with Touch ID
 scrt4 unlock --local    # should open the vault with no phone at all
 ```
+
+Prefer to build it yourself? `BUILD.md` covers that, and
+`scrt4 verify-self` will confirm a downloaded binary matches the published
+manifest.
 
 Any outcome is useful, including a failure — a clear report that it does not
 work is worth as much to us as one that says it does, and it saves the next
@@ -161,7 +177,7 @@ on disk:
 curl -fsSL https://install.llmsecrets.com/native | sh
 ```
 
-Linux (`x86_64`, `aarch64`) and macOS (Apple Silicon). `SCRT4_VERSION=v0.4.5`
+Linux (`x86_64`, `aarch64`) and macOS (Apple Silicon). `SCRT4_VERSION=v0.4.6`
 pins a specific release if you want one.
 
 Afterwards, `scrt4 upgrade` installs later releases — checksum-verified the
@@ -175,7 +191,7 @@ tag list here is source history; the channel above is what ships.
 
 ```bash
 scrt4 setup                        # one-time FIDO2 enrollment
-scrt4 setup --local                # add this device's own biometric (Windows today)
+scrt4 setup --local                # add this device's own biometric (see #54)
 scrt4 unlock                       # default 20-hour session
 scrt4 add API_KEY=sk-live-...      # add a secret
 scrt4 list                         # see names (never values)


### PR DESCRIPTION
The tester section in #53 listed three commands without saying where to get a scrt4 that has them.

Anyone following the install line before today got **v0.4.5**, where `setup --local` does not exist. Their first step would have failed with `Unknown command`, and the reasonable conclusion is that the instructions are wrong — not that they need a newer build.

## What this adds

```bash
# new install
curl -fsSL https://install.llmsecrets.com/native | sh

# already have scrt4?
scrt4 upgrade
```

Plus a version check (`scrt4 --version` should say `0.4.6` or later), so a mismatch is obvious rather than mysterious.

Also mentions building from source and `scrt4 verify-self` — for a tool that holds your secrets, "I would rather not take a binary on trust" is a fair instinct and worth answering in the same breath as asking someone to install one.

## Verified

**v0.4.6 is published and the channel points at it.** Walked the exact path a tester will take, on a clean box:

```
version: scrt4 v0.4.6
daemon:  active

setup --local       Add this device's own passkey (Touch ID / Windows ...
unlock [--local] [--agent] [ttl] Authenticate and start a session

scrt4 upgrade --check  ->  Already up to date.
scrt4 setup --local    ->  refuses correctly, names what to run first
scrt4 unlock --local   ->  refuses correctly, explains how to enrol
scrt4 verify-self      ->  ✓ Match — published 0.4.6 release
```

The downloads page checksums were updated in the same pass, which is the step that has gone stale after each of the last two releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTJgiGj5jV473VoBgTQATL