### PR TITLE
chore(crate): add licence, repository and README metadata

### DIFF
--- a/scrt4/daemon/Cargo.lock
+++ b/scrt4/daemon/Cargo.lock
@@ -1043,8 +1043,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrt4-daemon"
-version = "0.1.0"
+name = "scrt4"
+version = "0.4.6"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/scrt4/daemon/Cargo.toml
+++ b/scrt4/daemon/Cargo.toml
@@ -1,8 +1,21 @@
 [package]
-name = "scrt4-daemon"
-version = "0.1.0"
+# Published to crates.io as `scrt4`; the binary it installs stays
+# `scrt4-daemon`, which is what the clients and the service units invoke.
+name = "scrt4"
+version = "0.4.6"
 edition = "2021"
-description = "WebAuthn PRF secret manager daemon"
+rust-version = "1.74"
+description = "Hardware-bound secrets vault for AI coding agents. Secrets are injected into a subprocess and scrubbed from its output, so an agent can use a credential without ever seeing it. The vault key is derived from a FIDO2 authenticator via WebAuthn PRF and is never stored."
+license = "AGPL-3.0-only"
+repository = "https://github.com/llmsecrets/llm-secrets"
+homepage = "https://llmsecrets.com"
+documentation = "https://docs.llmsecrets.com"
+readme = "README.md"
+keywords = ["secrets", "webauthn", "fido2", "passkey", "vault"]
+categories = ["command-line-utilities", "cryptography", "authentication"]
+# Two binaries ship from here: scrt4-daemon owns the vault, and scrt4 is the
+# Rust client. The richer bash client is built separately by
+# scripts/build-scrt4.sh and is what the installers place on PATH.
 
 [dependencies]
 # Async runtime

--- a/scrt4/daemon/README.md
+++ b/scrt4/daemon/README.md
@@ -1,0 +1,67 @@
+# scrt4
+
+**Let an AI coding agent use your credentials without ever seeing them.**
+
+When Claude Code, Cursor, or any agent with shell access reads a `.env` file,
+your keys land in its context window — and in the prompt cache, the logs, and
+every error you paste afterwards. Nothing has gone wrong; the value is simply
+in more places than you can enumerate.
+
+scrt4 keeps secrets in an encrypted vault. The agent writes a command with a
+placeholder; the daemon substitutes the real value into that one subprocess
+and scrubs it back out of the output before anything returns to the model.
+
+```console
+$ scrt4 add STRIPE_SECRET_KEY=sk_live_...
+$ scrt4 run 'stripe --api-key $env[STRIPE_SECRET_KEY] charges list'
+```
+
+The agent sees the command. It never sees the value.
+
+## The key is not a file
+
+The vault key is derived from a FIDO2 authenticator via the WebAuthn PRF
+extension (CTAP2 `hmac-secret`), re-derived each session, and never written
+to disk.
+
+That distinction is the whole design. Encrypted-`.env` tools keep a private
+key on disk — anything that can read the filesystem can decrypt. There is no
+file to read here: opening the vault needs a tap on your phone, a security
+key, or Touch ID / Windows Hello.
+
+Encrypted `.env` is *git-safe*. This is *agent-safe*. Different problems.
+
+## Install
+
+```sh
+cargo install scrt4
+```
+
+That builds two binaries: `scrt4-daemon`, which owns the vault, and `scrt4`,
+the client that talks to it over a Unix socket (a named pipe on Windows).
+
+Prebuilt, checksum-verified binaries and the full bash client are at
+**<https://llmsecrets.com/downloads>**. `scrt4 verify-self` checks a running
+binary against the published manifest at any time.
+
+## What it does not do
+
+- It cannot help if you paste a secret into a chat window. Nothing can.
+- It does not touch your editor. If a completion model has already indexed a
+  file containing a key, that has happened.
+- It is not a team secrets manager — one person, their devices, their keys.
+- Lose the authenticator with no backup and the vault is gone. There is no
+  reset, because there is no server.
+
+## Platforms
+
+macOS (Apple Silicon), Linux (`x86_64` / `aarch64`, glibc 2.34+), Windows
+(PowerShell 5.1+), and WSL.
+
+## Links
+
+- Source and issues: <https://github.com/llmsecrets/llm-secrets>
+- Documentation: <https://docs.llmsecrets.com>
+- Threat model: [`SECURITY.md`](https://github.com/llmsecrets/llm-secrets/blob/main/scrt4/SECURITY.md)
+
+AGPL-3.0-only.


### PR DESCRIPTION
Housekeeping on `scrt4/daemon/Cargo.toml`, which was missing metadata that any Rust crate should carry.

## What was wrong

- **No `license` field** — the repository is AGPL-3.0 but the manifest did not say so
- No `repository`, `homepage` or `documentation`
- `version = "0.1.0"`, against a product shipping 0.4.6 — reads as abandoned to anyone who looks
- No crate README

## What changed

Adds the licence, repository, homepage, documentation, keywords and categories, and brings the version in line with the shipped release.

Adds `scrt4/daemon/README.md`. It leads with the problem rather than a feature list, states the `git-safe` vs `agent-safe` distinction, and keeps a short "what it does not do" section.

The package is renamed to match the product. **Both binary targets keep their names**, so `scrt4-daemon` is still what the service units and clients invoke; nothing downstream moves.

## The lockfile is deliberately a two-line diff

`cargo generate-lockfile` wanted to rewrite **563 lines**, downgrade the lock format v4 to v3, and move a dozen dependency versions. CI builds releases with `--locked`, so a metadata-only change must not quietly alter what gets compiled. The package entry was renamed by hand instead.

Verified afterwards: `cargo metadata --locked` still resolves, and `cargo package --list` produces 22 files, all already public in this repo.

## Note for whoever merges

Nothing syncs `Cargo.toml`'s version to the release tag — the bash client is stamped from `SCRT4_VERSION` at build time, but the crate version is manual. It will need bumping alongside future releases.
