### PR TITLE
Track the llmsecrets crate in git, and publish both crates on release

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,98 @@
+name: Publish to crates.io
+
+# Publishes `scrt4` and `llmsecrets` when a version tag is pushed, so the
+# registry tracks releases instead of drifting behind them.
+#
+# Deliberately a separate workflow from the binary release, and it waits for
+# that one to succeed first. A crates.io version is permanent — it can be
+# yanked but never replaced — so nothing is published until the same commit
+# has already passed the glibc floor, the command floor, and the runtime
+# routing check.
+
+on:
+  workflow_run:
+    workflows: ["Release native binaries"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.4.7)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # workflow_run fires on failure too; only a green release may publish.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Work out which tag we are publishing
+        id: tag
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.event.workflow_run.head_branch }}"
+          case "$TAG" in
+            v*.*.*) ;;
+            *) echo "not a version tag: $TAG — nothing to publish"; exit 1 ;;
+          esac
+          echo "tag=$TAG"            >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}"    >> "$GITHUB_OUTPUT"
+          echo "Publishing $TAG"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # The manifests carry a version for local builds, but the tag is the
+      # authority — otherwise every release needs someone to remember to bump
+      # two files, and the one time they forget the publish either fails or
+      # ships the wrong number.
+      - name: Set both manifest versions from the tag
+        run: |
+          set -euo pipefail
+          V='${{ steps.tag.outputs.version }}'
+          for f in scrt4/daemon/Cargo.toml crates/llmsecrets/Cargo.toml; do
+            # Only the [package] version — the first one in the file. A blunt
+            # global replace would rewrite dependency versions too.
+            awk -v v="$V" '
+              /^\[package\]/ { inpkg = 1 }
+              /^\[/ && !/^\[package\]/ { inpkg = 0 }
+              inpkg && /^version[ \t]*=/ && !done { print "version = \"" v "\""; done = 1; next }
+              { print }
+            ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+            echo "  $f -> $(grep -m1 '^version' "$f")"
+          done
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -uo pipefail
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "CARGO_REGISTRY_TOKEN is not set — add it in repository secrets"
+            exit 1
+          fi
+          V='${{ steps.tag.outputs.version }}'
+          fail=0
+          # scrt4 first: it is the crate people actually install.
+          for dir in scrt4/daemon crates/llmsecrets; do
+            name=$(grep -m1 '^name' "$dir/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+            echo "::group::$name $V"
+            # Re-running a tag must not fail the workflow; a version that is
+            # already up is the desired end state, not an error.
+            if curl -sf -A "scrt4-release (github actions)" \
+                 "https://crates.io/api/v1/crates/$name/$V" >/dev/null 2>&1; then
+              echo "$name $V is already on crates.io — skipping"
+            else
+              ( cd "$dir" && cargo publish --allow-dirty ) || fail=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $fail

--- a/crates/llmsecrets/.gitignore
+++ b/crates/llmsecrets/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/crates/llmsecrets/Cargo.toml
+++ b/crates/llmsecrets/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "llmsecrets"
+version = "0.4.6"
+edition = "2021"
+rust-version = "1.74"
+description = "LLM Secrets — hardware-bound secrets for AI coding agents. This crate is the project namespace; the installable tool is the `scrt4` crate."
+license = "AGPL-3.0-only"
+repository = "https://github.com/llmsecrets/llm-secrets"
+homepage = "https://llmsecrets.com"
+documentation = "https://docs.llmsecrets.com"
+readme = "README.md"
+keywords = ["secrets", "webauthn", "fido2", "passkey", "vault"]
+categories = ["cryptography", "authentication"]
+
+[dependencies]

--- a/crates/llmsecrets/README.md
+++ b/crates/llmsecrets/README.md
@@ -1,0 +1,53 @@
+# LLM Secrets
+
+**This crate is the project namespace. The tool you want is [`scrt4`](https://crates.io/crates/scrt4).**
+
+```sh
+cargo install scrt4
+```
+
+---
+
+## What the project does
+
+When an AI coding agent with shell access reads a `.env` file, your keys land
+in its context window — and in the prompt cache, the logs, and every error you
+paste afterwards. Nothing has gone wrong; the value is simply in more places
+than you can enumerate.
+
+LLM Secrets keeps secrets in an encrypted vault. The agent writes a command
+with a placeholder; the daemon substitutes the real value into that one
+subprocess and scrubs it back out of the output before anything returns to the
+model.
+
+```console
+$ scrt4 add STRIPE_SECRET_KEY=sk_live_...
+$ scrt4 run 'stripe --api-key $env[STRIPE_SECRET_KEY] charges list'
+```
+
+The agent sees the command. It never sees the value.
+
+## The key is not a file
+
+The vault key is derived from a FIDO2 authenticator via the WebAuthn PRF
+extension (CTAP2 `hmac-secret`), re-derived each session, and never written to
+disk.
+
+Encrypted-`.env` tools keep a private key on disk — anything that can read the
+filesystem can decrypt. There is no file to read here: opening the vault needs
+a tap on your phone, a security key, or Windows Hello.
+
+Encrypted `.env` is *git-safe*. This is *agent-safe*.
+
+## Not to be confused with
+
+The **`llm-secrets`** crate — with a hyphen — is an unrelated project by a
+different author. This one is <https://llmsecrets.com>.
+
+## Links
+
+- Install: `cargo install scrt4`, or <https://llmsecrets.com/downloads>
+- Source: <https://github.com/llmsecrets/llm-secrets>
+- Docs: <https://docs.llmsecrets.com>
+
+AGPL-3.0-only.

--- a/crates/llmsecrets/src/lib.rs
+++ b/crates/llmsecrets/src/lib.rs
@@ -1,0 +1,68 @@
+//! **LLM Secrets** — hardware-bound secrets for AI coding agents.
+//!
+//! This crate is the project's namespace on crates.io. It carries no
+//! implementation: the tool you want is [`scrt4`](https://crates.io/crates/scrt4).
+//!
+//! ```sh
+//! cargo install scrt4
+//! ```
+//!
+//! # What the project does
+//!
+//! When an agent with shell access reads a `.env` file, the values land in
+//! its context window, the prompt cache, and every error pasted afterwards.
+//! scrt4 keeps them in an encrypted vault instead. The agent writes a command
+//! containing a placeholder; the daemon substitutes the real value into that
+//! one subprocess and scrubs it back out of the output.
+//!
+//! ```text
+//! scrt4 add STRIPE_SECRET_KEY=sk_live_...
+//! scrt4 run 'stripe --api-key $env[STRIPE_SECRET_KEY] charges list'
+//! ```
+//!
+//! The agent sees the command. It never sees the value.
+//!
+//! The vault key is derived from a FIDO2 authenticator via the WebAuthn PRF
+//! extension and is never written to disk — so unlike an encrypted `.env`,
+//! there is no key file for an agent to read.
+//!
+//! # Not to be confused with
+//!
+//! The `llm-secrets` crate (with a hyphen) is an unrelated project by a
+//! different author. This one is <https://llmsecrets.com>.
+
+/// Where releases are published. Binaries are checksum-verified by the
+/// installer, and `scrt4 verify-self` re-checks a running binary against the
+/// same manifest.
+pub const DOWNLOADS: &str = "https://llmsecrets.com/downloads";
+
+/// Source and issue tracker.
+pub const REPOSITORY: &str = "https://github.com/llmsecrets/llm-secrets";
+
+/// Documentation.
+pub const DOCS: &str = "https://docs.llmsecrets.com";
+
+/// The crate that actually installs the tool.
+pub const CLI_CRATE: &str = "scrt4";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn links_are_https_and_point_at_the_project() {
+        for url in [DOWNLOADS, REPOSITORY, DOCS] {
+            assert!(url.starts_with("https://"), "{url} is not https");
+        }
+        assert!(DOWNLOADS.contains("llmsecrets.com"));
+        assert!(DOCS.contains("llmsecrets.com"));
+        assert!(REPOSITORY.contains("llmsecrets/llm-secrets"));
+    }
+
+    #[test]
+    fn points_at_the_unhyphenated_cli_crate() {
+        // `llm-secrets` is someone else's crate; naming it here by accident
+        // would send people to the wrong project.
+        assert_eq!(CLI_CRATE, "scrt4");
+    }
+}


### PR DESCRIPTION
Two gaps.

**The `llmsecrets` crate existed only on a laptop.** It was published to crates.io from a directory in nobody's version control, so nobody else could reproduce or update it. `crates/llmsecrets/` is now in the repository, tests included.

**Updating either crate was manual**, which means it quietly falls behind the releases. This publishes both on a version tag.

## Why it triggers on the release run, not the tag

A crates.io version is permanent — it can be yanked but never replaced. So this waits for **"Release native binaries" to succeed** on the same commit before publishing anything. A release that fails the glibc floor, the command floor, or the runtime routing check publishes nothing.

## The tag is the version authority

Both manifests still carry a version for local builds, but the workflow sets them from the tag at publish time:

```
scrt4/daemon/Cargo.toml      -> version = "0.4.7"
crates/llmsecrets/Cargo.toml -> version = "0.4.7"
```

Otherwise every release depends on someone remembering to bump two files, and the first time they forget it either fails or ships the wrong number. That was already flagged as a maintenance trap when the metadata landed.

The rewrite is scoped to the `[package]` version so dependency pins are untouched — verified against both real manifests, with the dependency-version count unchanged.

## Re-running a tag is safe

Each crate is checked against the registry first and skipped if that version is already up. A version already being published is the desired end state, not an error, so a re-run does not fail the workflow.

## Already done

`CARGO_REGISTRY_TOKEN` is set as a repository secret. The workflow fails with a clear message rather than a confusing cargo error if it ever goes missing.

## First real exercise

The next tag after this merges. Both crates are currently at 0.4.6 on crates.io, so a `v0.4.7` tag should publish both — and if this is merged and the next tag is cut without a release, the skip logic is what stops it from erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTJgiGj5jV473VoBgTQATL