### PR TITLE
security: publish the policy at the repo root and withdraw the old payout table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,176 @@
+# Security Policy
+
+<!--
+  Canonical security policy for this repository.
+
+  It lives at the repository root because GitHub only surfaces a policy from
+  /SECURITY.md, /.github/SECURITY.md or /docs/SECURITY.md. A copy in a
+  subdirectory is not shown on the Security tab and does not enable the
+  "Report a vulnerability" button.
+
+  PLACEHOLDER NOTES FOR MAINTAINERS (visible in raw source, so keep them free
+  of anything not intended to be public):
+    - Hall of Fame entries are added as reporters approve being named.
+    - The programme-status line is written to be true at all times; update it
+      when the position changes rather than leaving it aspirational.
+-->
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, **please report it responsibly**. Do
+not open a public GitHub issue.
+
+Preferred: **[Report a vulnerability](../../security/advisories/new)** through
+GitHub's private reporting. It creates a private draft advisory that only you
+and the maintainer can see, and it is the same object the eventual public
+advisory is published from — so you can review and correct it before anything
+goes out.
+
+Alternative: **security@llmsecrets.com**
+PGP key available on request (reply to your initial report).
+
+### What to Include
+
+- Description of the vulnerability and its impact
+- Steps to reproduce (proof of concept)
+- Affected component (daemon, CLI, relay, protocol)
+- Your suggested severity (Critical / High / Medium / Low)
+
+### Response Timeline
+
+| Stage | Target |
+|-------|--------|
+| First response | 48 hours |
+| Triage & severity assessment | 7 days |
+| Fix for Critical/High | 14 days |
+| Fix for Medium/Low | 30 days |
+| Public disclosure | After the fix is released, coordinated with the reporter |
+
+---
+
+## Rewards
+
+**Read this before you spend time on this project.** We would rather you decide
+with accurate information than find out afterwards.
+
+This is an unfunded project. It has no revenue and no security budget.
+
+An earlier version of this policy published a table promising $500–$2,000 for a
+Critical. That table was aspirational — written before the programme had
+received a single report, and before we knew what we could stand behind. It has
+been replaced with figures we can actually honour. If you reported against the
+old table, contact us: we will not treat you as having missed a window.
+
+Here is what we can genuinely offer.
+
+### Recognition — offered at full weight
+
+This is the part we can deliver, so we treat it as the primary reward rather
+than a consolation for the money.
+
+| | |
+|---|---|
+| **Featured highlight** | A dedicated security-researcher feature on llmsecrets.com — your name, the finding, and what changed because of it. Not a line in a list. |
+| **CVE** | Requested through a GitHub Security Advisory, formally crediting you. GitHub is a CNA, so the identifier is assigned directly. Permanent, indexed in the national vulnerability databases, citable indefinitely. |
+| **Advisory credit** | Your GitHub account in the advisory's structured Credits field, and an invitation onto the draft advisory before it is published. |
+| **Hall of Fame** | A permanent entry in this repository. |
+| **Commit credit** | `Co-Authored-By` on the commits your report shaped, plus changelog and release-note credit. |
+| **Reference** | A written reference from the maintainer at any point, if it is ever useful to you. |
+
+Credit goes up as soon as you approve it. We will not ask you to wait on work
+that is already done.
+
+**The published advisory is the one thing that waits**, and we would rather
+explain than let it look like a stall. An advisory carries the vulnerability
+details, and it is only useful to a reader once the fixed build is something
+they can actually install. Publishing before that point hands a working
+description of a live issue to the people still running the old version. So the
+advisory ships with the release that carries the fix — which is also the moment
+its "patched versions" field becomes a true statement rather than an aspiration.
+
+**Anonymity is always available** — before, during or after — and choosing it
+costs you nothing else on this list.
+
+### Money — small, and stated honestly
+
+| Severity | Payout |
+|---|---|
+| **Critical** | $50 |
+| **High / Medium / Low** | No cash payout at this time |
+
+That is the real number. It is far below what this document used to claim, and
+we would rather give you an accurate figure than negotiate you down from a
+fictional one.
+
+**Why nothing for High:** this project is young and its High-severity surface is
+still wide. We cannot fund a bounty at that volume yet. This is *not* a signal
+that High findings are unwelcome — they are among the most useful reports we
+receive, they are fixed on the same timeline as Criticals, and they earn every
+item in the recognition list above.
+
+We are obliged to confirm that recipients are not resident in a sanctioned
+jurisdiction. No identity verification is required at these amounts.
+
+If this project ever has funding behind it, we will revisit this table — and we
+will go back to the researchers who reported before it changed rather than
+treating them as having missed the window.
+
+### What we will not do
+
+- Publish a payout figure we cannot honour. That is the mistake this section
+  exists to correct.
+- Argue a finding down in severity to reduce what we owe. Severity is assessed
+  on impact; if you disagree with our assessment, say so and we will genuinely
+  reconsider.
+- Pursue legal action against anyone acting in good faith within this policy.
+
+---
+
+## Scope
+
+### In Scope
+
+- The daemon and its socket / named-pipe protocol
+- The CLI clients
+- The browser-based authentication page and its relay
+- Vault storage format and key wrapping
+- Anything that lets a caller obtain a secret value without the authorisation
+  the product claims to require
+
+### Out of Scope
+
+- Attacks requiring physical access to an unlocked machine
+- Social engineering of the maintainer or of users
+- Denial of service through resource exhaustion
+- Vulnerabilities in third-party dependencies without a demonstrated exploit
+  path through this project
+- Findings from automated scanners without a working proof of concept
+- Anything requiring a build with authentication deliberately disabled
+
+---
+
+## Disclosure Policy
+
+- We practise **coordinated disclosure**. Reporters get credit in the changelog
+  and release notes unless they prefer anonymity.
+- We aim to fix Critical/High issues before public disclosure.
+- If we are unresponsive beyond our stated timelines, reporters may disclose
+  after 90 days.
+- We will never pursue legal action against researchers acting in good faith
+  within this policy.
+
+---
+
+## Programme Status
+
+This programme received its first reports in **August 2026**. It is being
+formalised as it goes: private vulnerability reporting, the advisory workflow
+and this policy were all put in place in response to those first reports rather
+than before them. If something here is unclear or looks wrong, say so — the
+process is young enough that it is still worth changing.
+
+## Hall of Fame
+
+<!-- Entries are added as reporters approve being named. -->
+
+*No entries published yet.*

--- a/scrt4/SECURITY.md
+++ b/scrt4/SECURITY.md
@@ -24,18 +24,13 @@ If you discover a security vulnerability in scrt4, **please report it responsibl
 | Fix for Medium/Low | 30 days |
 | Public disclosure | After fix is released (coordinated with reporter) |
 
-### Bounty Rewards
+### Rewards
 
-Valid, original vulnerability reports are eligible for rewards:
+The reward terms for this programme are published in the security policy at the
+repository root: **[SECURITY.md](../SECURITY.md#rewards)**.
 
-| Severity | Payout | Examples |
-|----------|--------|----------|
-| **Critical** | $500 - $2,000 | Bypass WebAuthn to reveal secret values; master key extraction without authenticator; remote code execution via socket protocol |
-| **High** | $200 - $500 | Socket-level authentication bypass; vault decryption without PRF output; session hijacking across daemon restarts |
-| **Medium** | $50 - $200 | Timing attacks on challenge codes; WA verification window race conditions; audit log tampering or bypass |
-| **Low** | $25 - $50 | Secret name disclosure without values; information leaks in error messages; denial of service against daemon |
-
-Payouts are at the maintainer's discretion based on impact, quality of report, and exploitability. Bonus for high-quality reports with working PoC.
+That is the canonical version. The table that used to appear here quoted figures
+the project could not honour, and has been withdrawn rather than left standing.
 
 ---
 


### PR DESCRIPTION
## Why

**The policy was invisible.** GitHub only surfaces a security policy from `/SECURITY.md`, `/.github/SECURITY.md` or `/docs/SECURITY.md`. Ours lived at `scrt4/SECURITY.md` — one level down — so the Security tab showed no policy and the **Report a vulnerability** button was never offered. Researchers had no in-product route to reach us.

**The payout table promised money the project cannot pay.** `$500–$2,000` for a Critical, written before the programme had received a single report. Publishing a figure we cannot honour is worse than publishing a small one.

## What changed

- Adds `/SECURITY.md` as the canonical policy, so GitHub actually surfaces it and private vulnerability reporting becomes available
- Withdraws the old payout table; `scrt4/SECURITY.md` now points at the root policy so the two cannot drift apart
- Rewrites the rewards section to lead with **recognition**, which is what an unfunded project can deliver at full weight:
  - featured security-researcher highlight on llmsecrets.com
  - CVE via GitHub Security Advisory, with the reporter **invited onto the draft before publication**
  - Hall of Fame, `Co-Authored-By`, changelog credit
  - anonymity available before, during or after
- States cash honestly: **$50 Critical**, nothing for High/Medium/Low, with the reason given
- Explains why a published advisory waits for the release carrying the fix, so it does not read as a stall

Scope, response timelines, coordinated disclosure and the **safe-harbour commitment** are carried over unchanged.

## Placeholders

Hall of Fame entries and the programme-status note are deliberately left as placeholders, to be filled in as reporters approve being named.