### PR TITLE
security: require a WebAuthn step-up before enrolling an unlock credential

### DIFF
--- a/scrt4/daemon/src/handlers.rs
+++ b/scrt4/daemon/src/handlers.rs
@@ -974,6 +974,33 @@ async fn handle_setup_local() -> Response {
         }
     }
 
+    // Enrolling a NEW unlock credential is the most privileged thing this
+    // daemon does, and it was the one sensitive handler with no step-up while
+    // six others (reveal, reveal_all, backup_key, disable_wa,
+    // disable_wa_unlock, rotate_vault) all required one.
+    //
+    // The credential this creates is a permanent, session-independent path to
+    // the vault: it outlives the session that authorised it, survives logout,
+    // and keeps working after a master-key rotation. An active session is
+    // therefore not sufficient authority for it — otherwise any process able to
+    // reach the daemon socket while the user happened to be unlocked could
+    // enrol its own authenticator and retain access indefinitely, with no
+    // visible symptom because the vault keeps working normally.
+    //
+    // Dev mode skips the gate, matching the six handlers above.
+    {
+        let mut session = get_session().write().await;
+        if !keystore::is_dev_mode() && !session.consume_wa_verification(WA_VERIFY_WINDOW_SECS) {
+            audit::log_event(
+                AuditEvent::new(EventType::AuthFailure, EventResult::Failure)
+                    .with_error("setup_local without a WebAuthn step-up")
+            );
+            return Response::error(
+                "WebAuthn verification required before enrolling a local credential"
+            );
+        }
+    }
+
     let engine = base64::engine::general_purpose::STANDARD;
 
     let prf_salt = webauthn::generate_prf_salt();


### PR DESCRIPTION
Reported by an external security researcher (ref **LSR-2026-SGF5**), 18 Aug 2026.

`handle_setup_local` checked only that a session was active and held a master key. It was the **one** sensitive handler with no step-up, while six others — `reveal`, `reveal_all`, `backup_key`, `disable_wa`, `disable_wa_unlock`, `rotate_vault` — all required one.

## Why it matters

The credential this enrols is a permanent, session-independent path to the vault. It outlives the session that authorised it, survives logout, and keeps working after a master-key rotation. So an active session was never sufficient authority for it: any process able to reach the daemon socket while the user happened to be unlocked could enrol its own authenticator and retain access indefinitely — with no visible symptom, because the vault keeps working normally for the legitimate user.

The reporter also noted that the registration side performs no verification of *which* authenticator registered, so it wraps the master key for whatever credential the ceremony returns.

## The change

One `consume_wa_verification` call, in the same shape the six neighbouring handlers already use. Dev mode skips it, matching them.

**CVSS:3.1** `AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` → **7.1 High**

Rated more severely in triage than the vector suggests, because CVSS 3.1 has no metric for the *durability* of the compromise — the enrolled credential survives key rotation.

## Verification

Builds clean; 59 tests pass. `setup_local` now appears alongside the other six gated handlers.