### PR TITLE
security: keep the wrapping key out of the request line, and secrets out of argv

### DIFF
--- a/scrt4/auth-relay/public/auth.html
+++ b/scrt4/auth-relay/public/auth.html
@@ -269,7 +269,7 @@
     let challengeB64 = pick('c');
     let saltB64 = pick('salt');
     let credIdB64 = pick('cred');
-    // INV-RK-2: `k` is read from the FRAGMENT ONLY.
+    // `k` is read from the FRAGMENT ONLY.
     //
     // Deliberately not pick(), which prefers the query - a query-supplied k
     // would silently override the fragment, and a daemon that regressed to
@@ -277,7 +277,7 @@
     // k is what removes the only detector.
     const pickFragmentOnly = (name) => hashParams.get(name);
     let wrappingKeyHex = pickFragmentOnly('k');
-    // INV-RK-3: fail closed. A key supplied in the query has already reached the
+    // Fail closed. A key supplied in the query has already reached the
     // server's request line and must be treated as burned, never used.
     if (params.get('k')) {
       wrappingKeyHex = null;

--- a/scrt4/auth-relay/public/auth.html
+++ b/scrt4/auth-relay/public/auth.html
@@ -269,7 +269,20 @@
     let challengeB64 = pick('c');
     let saltB64 = pick('salt');
     let credIdB64 = pick('cred');
-    let wrappingKeyHex = pick('k');
+    // INV-RK-2: `k` is read from the FRAGMENT ONLY.
+    //
+    // Deliberately not pick(), which prefers the query - a query-supplied k
+    // would silently override the fragment, and a daemon that regressed to
+    // `?...&k=` would keep working instead of failing loudly. Accepting a query
+    // k is what removes the only detector.
+    const pickFragmentOnly = (name) => hashParams.get(name);
+    let wrappingKeyHex = pickFragmentOnly('k');
+    // INV-RK-3: fail closed. A key supplied in the query has already reached the
+    // server's request line and must be treated as burned, never used.
+    if (params.get('k')) {
+      wrappingKeyHex = null;
+      console.error('Refusing a wrapping key supplied in the URL query - it must be in the fragment (#k=).');
+    }
     let rpId = pick('rp') || 'auth.llmsecrets.com';
     let callbackUrl = pick('cb');
     let actionLabel = pick('a');
@@ -306,7 +319,7 @@
           challengeB64 = fpick('c');
           saltB64 = fpick('salt');
           credIdB64 = fpick('cred');
-          wrappingKeyHex = fpick('k');
+          wrappingKeyHex = fhp.get('k');   // fragment only here too
           rpId = fpick('rp') || 'auth.llmsecrets.com';
           callbackUrl = fpick('cb');
           actionLabel = fpick('a');

--- a/scrt4/daemon/src/subprocess.rs
+++ b/scrt4/daemon/src/subprocess.rs
@@ -12,20 +12,33 @@ pub struct RunResult {
     pub output: String,  // Sanitized
 }
 
-/// Shell-quote a value so it is treated as a single literal token by sh -c.
-/// Uses single quotes (which suppress all shell interpretation) and escapes
-/// any embedded single quotes via the '\'' idiom.
-#[cfg(unix)]
-fn shell_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
+// NOTE: `shell_quote` used to live here, in two cfg-gated forms. Its only
+// purpose was making a secret value survive as a literal inside the command
+// string — which is the defect itself, because that string becomes the child's
+// argv. Removed rather than left unused, so it cannot quietly come back, and
+// the whole class of quoting bugs goes with it.
+
+/// Environment-variable name a secret is exposed under inside the child.
+///
+/// Namespaced rather than using the bare secret name, so that a secret called
+/// `PATH`, `HOME` or `IFS` cannot clobber the child's real environment. The
+/// `$env[NAME]` syntax remains the user-facing contract.
+fn env_var_name(secret_name: &str) -> String {
+    format!("SCRT4_ENV_{}", secret_name)
 }
 
-/// cmd.exe counterpart: single quotes are literal characters there, so wrap
-/// in double quotes and escape embedded double quotes by doubling them
-/// (the Microsoft CRT argv parser's escape inside a quoted region).
+/// Shell reference that expands to the secret at runtime, inside the child.
+///
+/// Double-quoted so whitespace and newlines in the value survive expansion,
+/// which is also what lets multi-line secrets (SSH keys, PEM) work here.
+#[cfg(unix)]
+fn env_ref(secret_name: &str) -> String {
+    format!("\"${}\"", env_var_name(secret_name))
+}
+
 #[cfg(not(unix))]
-fn shell_quote(s: &str) -> String {
-    format!("\"{}\"", s.replace('"', "\"\""))
+fn env_ref(secret_name: &str) -> String {
+    format!("\"%{}%\"", env_var_name(secret_name))
 }
 
 /// Substitute $env[NAME] patterns with actual secret values
@@ -45,7 +58,7 @@ fn substitute_secrets(command: &str, secrets: &HashMap<String, String>) -> Resul
         match secrets.get(secret_name) {
             Some(value) => {
                 used_secrets.insert(secret_name.to_string(), value.clone());
-                result.replace_range(full_match.range(), &shell_quote(value));
+                result.replace_range(full_match.range(), &env_ref(secret_name));
             }
             None => {
                 return Err(format!("Secret not found: {}", secret_name));
@@ -63,7 +76,7 @@ pub async fn run_with_secrets(
     all_secrets: &HashMap<String, String>,
 ) -> Result<RunResult, String> {
     // Substitute $env[NAME] patterns
-    let (substituted_cmd, _used_secrets) = substitute_secrets(command, all_secrets)?;
+    let (substituted_cmd, used_secrets) = substitute_secrets(command, all_secrets)?;
 
     tracing::info!("Running command (secrets substituted)");
 
@@ -79,14 +92,23 @@ pub async fn run_with_secrets(
         use std::os::windows::process::CommandExt;
         let mut c = Command::new("cmd");
         c.arg("/c");
-        // raw_arg, not arg: `arg` applies MSVC argv escaping, which rewrites
-        // the `"` our shell_quote emits into `\"`. cmd.exe does not use MSVC
-        // rules, so it would pass those backslashes through literally.
-        // Caveat: cmd expands %VAR% even inside double quotes, so a secret
-        // containing %NAME% is subject to environment expansion.
+        // raw_arg, not arg: `arg` applies MSVC argv escaping, which cmd.exe does
+        // not use. The command string now carries only %SCRT4_ENV_*% references
+        // and never a secret value, so the escaping hazard that used to matter
+        // here — including cmd expanding a %NAME% that appeared inside a secret —
+        // is gone along with the splicing.
         c.as_std_mut().raw_arg(&substituted_cmd);
         c
     };
+
+    // The values reach the child ONLY through its environment, and only the
+    // secrets this command actually references — never the whole vault.
+    // /proc/<pid>/environ is mode 0400 and owner-only; /proc/<pid>/cmdline is
+    // world-readable, which is precisely why the value is no longer in the
+    // command string.
+    for (name, value) in &used_secrets {
+        cmd.env(env_var_name(name), value);
+    }
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
@@ -132,6 +154,21 @@ pub async fn run_with_secrets(
 mod tests {
     use super::*;
 
+    /// Every rewritten test asserts the same property: the command REFERENCES
+    /// the secret, and never CONTAINS it. These tests previously asserted the
+    /// spliced value, i.e. they encoded the defect - so they are inverted
+    /// rather than deleted, keeping the behaviour covered.
+    fn assert_no_plaintext(cmd: &str, values: &[&str]) {
+        for v in values {
+            assert!(
+                !cmd.contains(v),
+                "value {:?} appears in the command string, which becomes the                  child's argv and is world-readable via /proc/<pid>/cmdline:
+  {}",
+                v, cmd
+            );
+        }
+    }
+
     #[test]
     fn test_substitute_single() {
         let mut secrets = HashMap::new();
@@ -139,10 +176,8 @@ mod tests {
 
         let (result, used) = substitute_secrets("echo $env[KEY]", &secrets).unwrap();
 
-        #[cfg(unix)]
-        assert_eq!(result, "echo 'value123'");
-        #[cfg(not(unix))]
-        assert_eq!(result, "echo \"value123\"");
+        assert_no_plaintext(&result, &["value123"]);
+        assert!(result.contains("SCRT4_ENV_KEY"), "must reference the env var: {}", result);
         assert_eq!(used.get("KEY"), Some(&"value123".to_string()));
     }
 
@@ -152,20 +187,17 @@ mod tests {
         secrets.insert("A".to_string(), "aaa".to_string());
         secrets.insert("B".to_string(), "bbb".to_string());
 
-        let (result, _) = substitute_secrets("$env[A] and $env[B]", &secrets).unwrap();
+        let (result, used) = substitute_secrets("$env[A] and $env[B]", &secrets).unwrap();
 
-        #[cfg(unix)]
-        assert_eq!(result, "'aaa' and 'bbb'");
-        #[cfg(not(unix))]
-        assert_eq!(result, "\"aaa\" and \"bbb\"");
+        assert_no_plaintext(&result, &["aaa", "bbb"]);
+        assert!(result.contains("SCRT4_ENV_A") && result.contains("SCRT4_ENV_B"));
+        assert_eq!(used.len(), 2);
     }
 
     #[test]
     fn test_substitute_missing() {
         let secrets = HashMap::new();
-
         let result = substitute_secrets("$env[MISSING]", &secrets);
-
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Secret not found: MISSING"));
     }
@@ -173,9 +205,7 @@ mod tests {
     #[test]
     fn test_substitute_no_secrets() {
         let secrets = HashMap::new();
-
         let (result, used) = substitute_secrets("echo hello", &secrets).unwrap();
-
         assert_eq!(result, "echo hello");
         assert!(used.is_empty());
     }
@@ -188,44 +218,91 @@ mod tests {
 
         let (result, _) = substitute_secrets("$env[USER]:$env[PASS]", &secrets).unwrap();
 
-        #[cfg(unix)]
-        assert_eq!(result, "'admin':'secret'");
-        #[cfg(not(unix))]
-        assert_eq!(result, "\"admin\":\"secret\"");
+        assert_no_plaintext(&result, &["admin", "secret"]);
+        assert!(result.contains("SCRT4_ENV_USER") && result.contains("SCRT4_ENV_PASS"));
+        assert!(result.contains(':'), "the literal separator must survive: {}", result);
     }
 
     #[test]
     fn test_substitute_shell_metacharacters() {
+        // The old code had to shell-quote these. A reference cannot carry them
+        // at all, so the whole class of quoting bugs disappears with the value.
         let mut secrets = HashMap::new();
         secrets.insert("PASS".to_string(), "h3llo W*rld!".to_string());
 
         let (result, _) = substitute_secrets("VAR=$env[PASS] cmd", &secrets).unwrap();
 
-        #[cfg(unix)]
-        assert_eq!(result, "VAR='h3llo W*rld!' cmd");
-        #[cfg(not(unix))]
-        assert_eq!(result, "VAR=\"h3llo W*rld!\" cmd");
+        assert_no_plaintext(&result, &["h3llo W*rld!", "W*rld"]);
+        assert!(result.starts_with("VAR="), "surrounding text preserved: {}", result);
+        assert!(result.ends_with(" cmd"));
     }
 
     #[test]
-    #[cfg(unix)]
-    fn test_substitute_embedded_single_quote() {
-        let mut secrets = HashMap::new();
-        secrets.insert("VAL".to_string(), "it's here".to_string());
-
-        let (result, _) = substitute_secrets("echo $env[VAL]", &secrets).unwrap();
-
-        assert_eq!(result, "echo 'it'\\''s here'");
-    }
-
-    #[test]
-    #[cfg(not(unix))]
     fn test_substitute_embedded_double_quote() {
+        // Previously asserted the exact escaping of embedded quotes. There is
+        // nothing left to escape.
         let mut secrets = HashMap::new();
-        secrets.insert("VAL".to_string(), "say \"hi\" now".to_string());
+        secrets.insert("SQ".to_string(), "it's here".to_string());
+        secrets.insert("DQ".to_string(), "say \"hi\" now".to_string());
 
-        let (result, _) = substitute_secrets("echo $env[VAL]", &secrets).unwrap();
+        let (r1, _) = substitute_secrets("echo $env[SQ]", &secrets).unwrap();
+        let (r2, _) = substitute_secrets("echo $env[DQ]", &secrets).unwrap();
 
-        assert_eq!(result, "echo \"say \"\"hi\"\" now\"");
+        assert_no_plaintext(&r1, &["it's here"]);
+        assert_no_plaintext(&r2, &["say \"hi\" now", "hi"]);
+    }
+
+    #[test]
+    fn no_secret_value_reaches_the_command_string() {
+        // The command string becomes the argument to `sh -c` / `cmd /c`, i.e.
+        // the child's argv. On Linux /proc/<pid>/cmdline is world-readable, so a
+        // value here is disclosed to every local user for the lifetime of the
+        // command - not merely to the same user.
+        let mut secrets = HashMap::new();
+        let sensitive = [
+            ("API", "sk_live_deadbeefcafe"),
+            ("MULTI", "-----BEGIN KEY-----
+line2
+-----END KEY-----"),
+            ("WEIRD", "va'lue\"with$pecials"),
+        ];
+        for (k, v) in sensitive {
+            secrets.insert(k.to_string(), v.to_string());
+        }
+
+        let (cmd, used) =
+            substitute_secrets("run $env[API] $env[MULTI] $env[WEIRD]", &secrets).unwrap();
+
+        for (_, v) in sensitive {
+            assert!(!cmd.contains(v), "value {:?} leaked into:
+  {}", v, cmd);
+        }
+        assert_eq!(used.len(), 3);
+        assert_eq!(used.get("API").map(String::as_str), Some("sk_live_deadbeefcafe"));
+    }
+
+    #[test]
+    fn env_var_is_namespaced_so_it_cannot_clobber_the_child() {
+        // A secret named PATH must not become $PATH in the child.
+        assert_eq!(env_var_name("PATH"), "SCRT4_ENV_PATH");
+        assert_ne!(env_var_name("PATH"), "PATH");
+        let mut secrets = HashMap::new();
+        secrets.insert("PATH".to_string(), "/evil".to_string());
+        let (cmd, _) = substitute_secrets("echo $env[PATH]", &secrets).unwrap();
+        assert!(cmd.contains("SCRT4_ENV_PATH"));
+        assert!(!cmd.contains("/evil"));
+    }
+
+    #[test]
+    fn multiline_secret_reference_is_double_quoted() {
+        // Double quoting preserves newlines when the shell expands the variable;
+        // an unquoted $VAR would word-split an SSH key.
+        let mut secrets = HashMap::new();
+        secrets.insert("K".to_string(), "a
+b".to_string());
+        let (cmd, _) = substitute_secrets("cat $env[K]", &secrets).unwrap();
+        assert!(cmd.contains('"'), "reference must be double-quoted: {}", cmd);
+        assert!(!cmd.contains("a
+b"));
     }
 }

--- a/scrt4/daemon/src/webauthn.rs
+++ b/scrt4/daemon/src/webauthn.rs
@@ -303,13 +303,13 @@ pub fn generate_register_params() -> Result<RelaySetupParams, String> {
     rand::thread_rng().fill_bytes(&mut challenge_bytes);
 
     let url = format!(
-        "{}?m=register&s={}&c={}&salt={}&k={}&rp={}",
+        "{}?m=register&s={}&c={}&salt={}&rp={}#k={}",
         AUTH_PAGE_BASE,
         session_id,
         engine.encode(challenge_bytes),
         engine.encode(&prf_salt),
-        wrapping_key,
-        "auth.llmsecrets.com"
+        "auth.llmsecrets.com",
+        wrapping_key
     );
 
     Ok(RelaySetupParams {
@@ -332,14 +332,14 @@ pub fn generate_auth_params(
     rand::thread_rng().fill_bytes(&mut challenge_bytes);
 
     let url = format!(
-        "{}?m=auth&s={}&c={}&salt={}&cred={}&k={}&rp={}",
+        "{}?m=auth&s={}&c={}&salt={}&cred={}&rp={}#k={}",
         AUTH_PAGE_BASE,
         session_id,
         engine.encode(challenge_bytes),
         engine.encode(salt),
         &credential.credential_id,
-        wrapping_key,
-        "auth.llmsecrets.com"
+        "auth.llmsecrets.com",
+        wrapping_key
     );
 
     Ok(RelaySetupParams {


### PR DESCRIPTION
Two findings from the same external researcher (ref **LSR-2026-MBAV**), 19 Aug 2026.

## 1. Wrapping key in the URL query string

Both relay URL builders emitted `...&k=<wrapping_key>&rp=...`. A query string is part of the HTTP **request target**, so the key reaches the server's request line, its access logs, and any proxy in front of it. A URL **fragment** is stripped by the browser before the request is built, and is the correct place for it.

Fixed on both sides, because either alone is insufficient:

- **daemon** — both builders now emit `...&rp=...#k=<key>`
- **browser** — `auth.html` reads `k` from the fragment **only**, and *refuses* a key supplied in the query rather than falling back to it. The previous helper preferred the query, so a daemon that regressed would have kept working silently. Failing closed is what makes the daemon-side fix detectable.

**CVSS:3.1** `AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N` → **6.8 Medium**
`AC:H` because log access alone yields the PRF output, not the vault — reaching secrets also requires the victim's `master.key` and vault file, which is a separate compromise.

## 2. Plaintext secrets in argv

`$env[NAME]` spliced the secret **value** into the command string, which becomes the argument to `sh -c` / `cmd /c` — i.e. the child's argv. On Linux `/proc/<pid>/cmdline` is **world-readable**, so the value was exposed to every local user for the lifetime of the command.

`$env[NAME]` now expands to a namespaced **reference** (`"$SCRT4_ENV_NAME"` / `"%SCRT4_ENV_NAME%"`) and the value is passed via `Command::env`. `/proc/<pid>/environ` is mode 0400 and owner-only.

- Namespaced so a secret called `PATH`, `HOME` or `IFS` cannot clobber the child's environment
- Only the secrets a command actually references are exported, never the whole vault
- `shell_quote` **removed**, not left unused — its only purpose was making a value survive as a literal in argv, which is the defect. The whole class of quoting bugs goes with it, including cmd.exe expanding a `%NAME%` that appeared inside a secret value.

**CVSS:3.1** `AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` → **5.5 Medium**

### ⚠️ Behaviour change

`echo '$env[K]'` (single quotes) no longer expands — single quotes suppress shell expansion. Splicing the value in was what made that case work, and that is exactly what is being removed. Unquoted and double-quoted forms are unchanged.

## Verification

Builds clean; **62 tests pass**. The six existing substitution tests asserted the spliced *value* — they encoded the defect, so each was **inverted rather than deleted**: the command must now contain the reference and must not contain the value.