### PR TITLE
security: bind the session to a token the client must present

### DIFF
--- a/scrt4/daemon/bin/scrt4-core
+++ b/scrt4/daemon/bin/scrt4-core
@@ -304,9 +304,43 @@ export -f _bg_if_gui
 # This is the only path through which CLI code reaches the daemon. All
 # vault and session state is owned by the daemon; the CLI is a thin
 # client that authenticates the user and shapes commands.
+# ── INV-SK-1: the session token ──────────────────────────────────────
+#
+# The daemon returns a token when it unlocks, and every request that touches
+# the unlocked session must present it. Stored beside the vault with umask 077.
+#
+# Worth being plain about what this is and is not: a same-user attacker can
+# read this file. It converts the attack from "open the socket" - which leaves
+# no artifact - into "read a specific named file", which is a discrete act on
+# a known path. It is not a boundary against a fully same-user adversary.
+SESSION_TOKEN_FILE="${CONFIG_DIR}/session.token"
+
+_save_session_token() {
+    local tok="$1"
+    [ -n "$tok" ] || return 0
+    ( umask 077; printf '%s' "$tok" > "$SESSION_TOKEN_FILE" ) 2>/dev/null || return 0
+}
+
+_clear_session_token() {
+    rm -f "$SESSION_TOKEN_FILE" 2>/dev/null || true
+}
+
+_load_session_token() {
+    [ -r "$SESSION_TOKEN_FILE" ] || return 0
+    cat "$SESSION_TOKEN_FILE" 2>/dev/null || true
+}
+
 send_request() {
     local json="$1"
     local timeout="${2:-10}"
+    # Attached to EVERY request. The client deliberately does not classify
+    # which methods need a token - session_binding::binding in the daemon is
+    # the single source of that decision, so the two cannot drift.
+    local _tok
+    _tok=$(_load_session_token)
+    if [ -n "$_tok" ] && command -v jq >/dev/null 2>&1; then
+        json=$(jq -c --arg t "$_tok" '. + {session_token:$t}' <<< "$json" 2>/dev/null) || json="$1"
+    fi
     # If the socket doesn't exist, tell the user instead of swallowing the
     # failure. This used to silently return empty, leaving callers with
     # "Setup failed: Unknown error" or (worse) no output at all.
@@ -634,6 +668,8 @@ run_unlock_flow() {
     if [ "$success" = "true" ]; then
         local count
         count=$(echo "$response" | jq -r '.data.count // 0')
+        # INV-SK-1: the daemon returns the session token here and ONLY here.
+        _save_session_token "$(echo "$response" | jq -r '.data.session_token // empty')"
         echo -e "${GREEN}Unlocked ${count} secret(s).${NC}"
     else
         local error
@@ -1300,6 +1336,9 @@ cmd_rotate() {
 #   - clear   (alias, same behaviour — listed in the v0.1.0 menu)
 cmd_logout() {
     send_request '{"method":"clear"}'
+    # The token is dead the moment the session is - keeping it on disk would
+    # leave a credential lying around that authenticates nothing.
+    _clear_session_token
 }
 
 # cmd_backup_vault [--local DIR] — tar the vault directory into a

--- a/scrt4/daemon/bin/scrt4-core
+++ b/scrt4/daemon/bin/scrt4-core
@@ -304,7 +304,7 @@ export -f _bg_if_gui
 # This is the only path through which CLI code reaches the daemon. All
 # vault and session state is owned by the daemon; the CLI is a thin
 # client that authenticates the user and shapes commands.
-# ── INV-SK-1: the session token ──────────────────────────────────────
+# ── the session token ──────────────────────────────────────
 #
 # The daemon returns a token when it unlocks, and every request that touches
 # the unlocked session must present it. Stored beside the vault with umask 077.
@@ -668,7 +668,7 @@ run_unlock_flow() {
     if [ "$success" = "true" ]; then
         local count
         count=$(echo "$response" | jq -r '.data.count // 0')
-        # INV-SK-1: the daemon returns the session token here and ONLY here.
+        # the daemon returns the session token here and ONLY here.
         _save_session_token "$(echo "$response" | jq -r '.data.session_token // empty')"
         echo -e "${GREEN}Unlocked ${count} secret(s).${NC}"
     else

--- a/scrt4/daemon/src/handlers.rs
+++ b/scrt4/daemon/src/handlers.rs
@@ -80,7 +80,7 @@ async fn handle_request(line: &str) -> Response {
         }
     };
 
-    // INV-SK-1: a request that uses the unlocked session must present the token
+    // a request that uses the unlocked session must present the token
     // minted when it was unlocked. Checked HERE, once, ahead of the dispatch —
     // not inside each handler — so a handler cannot be added without the check,
     // and so the classification lives in exactly one place
@@ -107,10 +107,10 @@ async fn handle_request(line: &str) -> Response {
             // then `run`) that this layer exists to break.
             audit::log_event(
                 AuditEvent::new(EventType::AuthFailure, EventResult::Failure)
-                    .with_error("session token missing or invalid (INV-SK-1)")
+                    .with_error("session token missing or invalid")
             );
             tracing::warn!(
-                "refused a request that requires the session token (INV-SK-1); \
+                "refused a request that requires the session token; \
                  token_presented={}",
                 envelope.session_token.is_some()
             );
@@ -745,7 +745,7 @@ async fn handle_unlock_webauthn_complete(
             );
             Response::ok_with_data(ResponseData::Unlocked {
                 count,
-                // INV-SK-1: the only path the token leaves the daemon by.
+                // the only path the token leaves the daemon by.
                 session_token: session.token_b64(),
             })
         }
@@ -1006,7 +1006,7 @@ async fn handle_unlock_local_complete(ttl: Option<u64>) -> Response {
             );
             Response::ok_with_data(ResponseData::Unlocked {
                 count,
-                // INV-SK-1: the only path the token leaves the daemon by.
+                // the only path the token leaves the daemon by.
                 session_token: session.token_b64(),
             })
         }

--- a/scrt4/daemon/src/handlers.rs
+++ b/scrt4/daemon/src/handlers.rs
@@ -6,7 +6,7 @@ use crate::audit::{self, AuditEvent, EventType, EventResult};
 use crate::keystore;
 use crate::localhost;
 use crate::webauthn;
-use crate::protocol::{Request, Response, ResponseData};
+use crate::protocol::{Envelope, Request, Response, ResponseData};
 use crate::session::SharedSession;
 use crate::subprocess::run_with_secrets;
 
@@ -79,6 +79,48 @@ async fn handle_request(line: &str) -> Response {
             return Response::error(format!("Invalid request: {}", e));
         }
     };
+
+    // INV-SK-1: a request that uses the unlocked session must present the token
+    // minted when it was unlocked. Checked HERE, once, ahead of the dispatch —
+    // not inside each handler — so a handler cannot be added without the check,
+    // and so the classification lives in exactly one place
+    // (`session_binding::binding`, which has no wildcard arm).
+    //
+    // The envelope is parsed separately from `Request`: the token authenticates
+    // the CHANNEL, the request describes the OPERATION.
+    //
+    // A malformed envelope is treated as "no token" rather than a parse error —
+    // its only field is optional, so the sole way to fail is a line that is not
+    // an object, which `Request` has already rejected above.
+    if crate::session_binding::requires_token(&request) {
+        let envelope: Envelope = serde_json::from_str(line).unwrap_or_default();
+
+        let ok = match envelope.session_token.as_deref() {
+            Some(t) => get_session().read().await.verify_token(t),
+            None => false,
+        };
+
+        if !ok {
+            // ⚠️ ONE message for absent, malformed, wrong, and no-active-session.
+            // Distinguishing them would hand an unauthenticated caller an oracle
+            // for session state — which is the reconnaissance step (`status`,
+            // then `run`) that this layer exists to break.
+            audit::log_event(
+                AuditEvent::new(EventType::AuthFailure, EventResult::Failure)
+                    .with_error("session token missing or invalid (INV-SK-1)")
+            );
+            tracing::warn!(
+                "refused a request that requires the session token (INV-SK-1); \
+                 token_presented={}",
+                envelope.session_token.is_some()
+            );
+            return Response::error(
+                "This request requires the session token from `scrt4 unlock`. \
+                 Run `scrt4 unlock` in this shell, or re-run it if the session \
+                 was started elsewhere."
+            );
+        }
+    }
 
     match request {
         Request::Store { token, secrets, ttl } => handle_store(token, secrets, ttl).await,
@@ -206,7 +248,12 @@ async fn handle_add_secrets(
                 AuditEvent::new(EventType::SecretsAdded, EventResult::Success)
                     .with_secret_count(added)
             );
-            Response::ok_with_data(ResponseData::Unlocked { count })
+            Response::ok_with_data(ResponseData::Unlocked {
+                count,
+                // Not an unlock: this reuses an existing session, so it must
+                // not reissue the token to whoever called it.
+                session_token: None,
+            })
         }
         Err(e) => {
             audit::log_event(
@@ -696,7 +743,11 @@ async fn handle_unlock_webauthn_complete(
                     .with_ttl(ttl_secs)
                     .with_secret_count(count)
             );
-            Response::ok_with_data(ResponseData::Unlocked { count })
+            Response::ok_with_data(ResponseData::Unlocked {
+                count,
+                // INV-SK-1: the only path the token leaves the daemon by.
+                session_token: session.token_b64(),
+            })
         }
         Err(e) => Response::error(e),
     }
@@ -953,7 +1004,11 @@ async fn handle_unlock_local_complete(ttl: Option<u64>) -> Response {
                     .with_ttl(ttl_secs)
                     .with_secret_count(count)
             );
-            Response::ok_with_data(ResponseData::Unlocked { count })
+            Response::ok_with_data(ResponseData::Unlocked {
+                count,
+                // INV-SK-1: the only path the token leaves the daemon by.
+                session_token: session.token_b64(),
+            })
         }
         Err(e) => Response::error(e),
     }

--- a/scrt4/daemon/src/main.rs
+++ b/scrt4/daemon/src/main.rs
@@ -6,6 +6,7 @@ use tokio::net::UnixListener;
 
 mod protocol;
 mod session;
+mod session_binding;
 mod handlers;
 mod sanitize;
 mod subprocess;

--- a/scrt4/daemon/src/protocol.rs
+++ b/scrt4/daemon/src/protocol.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// The wire envelope that carries the session token (INV-SK-1).
+/// The wire envelope that carries the session token.
 ///
 /// Parsed SEPARATELY from `Request` so the token authenticates the CHANNEL
 /// while the request describes the OPERATION. Keeping them apart means a
@@ -235,7 +235,7 @@ pub enum ResponseData {
     RevealAll { secrets: HashMap<String, String> },
     Unlocked {
         count: usize,
-        /// INV-SK-1: the session token, returned ONLY here — on the
+        /// the session token, returned ONLY here — on the
         /// connection that performed the unlock ceremony. Never in
         /// `status`, an error, or a log line.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/scrt4/daemon/src/protocol.rs
+++ b/scrt4/daemon/src/protocol.rs
@@ -2,6 +2,18 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// The wire envelope that carries the session token (INV-SK-1).
+///
+/// Parsed SEPARATELY from `Request` so the token authenticates the CHANNEL
+/// while the request describes the OPERATION. Keeping them apart means a
+/// token can never be mistaken for part of the operation.
+#[derive(Debug, Default, Deserialize)]
+pub struct Envelope {
+    /// Session token from the unlock that established this session, base64.
+    #[serde(default)]
+    pub session_token: Option<String>,
+}
+
 /// Request from client to daemon
 #[derive(Debug, Deserialize)]
 #[serde(tag = "method", content = "params")]
@@ -221,7 +233,14 @@ pub enum ResponseData {
     Reveal { value: String },
     Challenge { challenge: String, prompt: String, code: String },
     RevealAll { secrets: HashMap<String, String> },
-    Unlocked { count: usize },
+    Unlocked {
+        count: usize,
+        /// INV-SK-1: the session token, returned ONLY here — on the
+        /// connection that performed the unlock ceremony. Never in
+        /// `status`, an error, or a log line.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session_token: Option<String>,
+    },
     Extended { remaining: i64 },
     BackupKey { key: String },
     WaState { configured: bool, enabled: bool, unlock_enabled: bool },

--- a/scrt4/daemon/src/session.rs
+++ b/scrt4/daemon/src/session.rs
@@ -395,6 +395,73 @@ impl Session {
             None => Err("No secrets available".into()),
         }
     }
+
+
+    /// The active session's token, base64, for handing back to the client that
+    /// unlocked it (INV-SK-1).
+    ///
+    /// ⚠️ This is the ONLY way the token leaves the daemon, and it is called on
+    /// exactly one path: the response to a successful unlock, delivered over the
+    /// connection that performed the ceremony. It must never be added to
+    /// `status`, to an error, or to a log line — a token readable without
+    /// authenticating is a token that authenticates nothing.
+    pub fn token_b64(&self) -> Option<String> {
+        use base64::Engine;
+        self.token
+            .as_ref()
+            .map(|t| base64::engine::general_purpose::STANDARD.encode(t))
+    }
+
+    /// Does `presented` match the active session's token? (INV-SK-1)
+    ///
+    /// Fails closed on every path: no active session, malformed base64, wrong
+    /// length and wrong bytes all return `false`, and the caller reports one
+    /// message for all of them. Distinguishing "no session" from "wrong token"
+    /// would let an unauthenticated caller probe session state through the
+    /// error text, which is the recon step this is meant to close.
+    ///
+    /// The comparison is constant time in the LENGTH-EQUAL case. An unequal
+    /// length returns early, which leaks only that — and the length is fixed at
+    /// 32 bytes by `store`, so it is public knowledge, not a secret.
+    pub fn verify_token(&self, presented: &str) -> bool {
+        use base64::Engine;
+
+        // Check liveness first, but do not return yet: an expired session and a
+        // wrong token must take the same path out.
+        let live = self.is_active();
+
+        let expected = match self.token.as_ref() {
+            Some(t) => t,
+            None => return false,
+        };
+
+        let got = match base64::engine::general_purpose::STANDARD.decode(presented) {
+            Ok(b) => b,
+            Err(_) => return false,
+        };
+
+        if got.len() != expected.len() {
+            return false;
+        }
+
+        // Hand-rolled rather than pulled in as a dependency: this is four lines
+        // and adding a crate to the TCB for them is the worse trade. The
+        // accumulator must be folded AFTER the whole loop — an early `return`
+        // on first mismatch is exactly the timing leak being avoided here.
+        let mut diff: u8 = 0;
+        for (a, b) in expected.iter().zip(got.iter()) {
+            diff |= a ^ b;
+        }
+
+        // Zeroize the decoded copy: it is the caller's secret and it is ours to
+        // clean up, and on the failure paths above it never existed.
+        let mut got = got;
+        for b in got.iter_mut() {
+            *b = 0;
+        }
+
+        live && diff == 0
+    }
 }
 
 /// Thread-safe session state

--- a/scrt4/daemon/src/session.rs
+++ b/scrt4/daemon/src/session.rs
@@ -398,7 +398,7 @@ impl Session {
 
 
     /// The active session's token, base64, for handing back to the client that
-    /// unlocked it (INV-SK-1).
+    /// unlocked it.
     ///
     /// ⚠️ This is the ONLY way the token leaves the daemon, and it is called on
     /// exactly one path: the response to a successful unlock, delivered over the
@@ -412,7 +412,7 @@ impl Session {
             .map(|t| base64::engine::general_purpose::STANDARD.encode(t))
     }
 
-    /// Does `presented` match the active session's token? (INV-SK-1)
+    /// Does `presented` match the active session's token?
     ///
     /// Fails closed on every path: no active session, malformed base64, wrong
     /// length and wrong bytes all return `false`, and the caller reports one

--- a/scrt4/daemon/src/session_binding.rs
+++ b/scrt4/daemon/src/session_binding.rs
@@ -1,0 +1,311 @@
+// TCB: session binding
+// Verifies: a request that uses an unlocked session must present the session
+//           token minted when that session was unlocked. Opening a socket
+//           connection is not, by itself, authority to spend the session.
+// Adversary: a same-user process that waits for the victim to unlock, opens its
+//            own connection, and calls `run`/`reveal` against the session it
+//            never authenticated to.
+//
+// ━━━ Why this exists ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+// Reported externally as S4-006. The daemon held ONE global session and
+// `handle_connection` carried no per-connection state, so every connection was
+// equally entitled to it. The reporter's proof of concept is three steps:
+//
+//   1. client A unlocks, then DISCONNECTS
+//   2. client B opens a fresh connection, sends no token, calls `status`,
+//      and sees `{"active":true,"remaining":599}`
+//   3. client B calls `run` with `$env[SECRET] | base64`, and the daemon
+//      substitutes the real value
+//
+// The value comes back base64-encoded, so `sanitize`'s literal redaction does
+// not match it and the plaintext is recovered. That second half is NOT fixable
+// in the sanitizer — a caller who can run an arbitrary command with a secret in
+// its environment can apply any transformation it likes, and no output filter
+// can chase every encoding. The fixable half is step 2: client B should never
+// have been able to reach `run` at all.
+//
+// A 32-byte token was already minted at unlock and kept in `Session::token`.
+// Nothing ever returned it to the client and no handler ever checked it, so it
+// authenticated nothing. This module is the policy half of making it mean
+// something; `Session::verify_token` is the mechanism half.
+//
+// ━━━ What this does and does not buy ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+// ⚠️ Stated plainly because the distinction matters more than the fix:
+//
+// The client persists the token to a file only its owner can read. A same-user
+// attacker can read that file — same uid, and on Windows the vault directory
+// ACL is owner-plus-SYSTEM, which the attacker satisfies. So this is NOT a
+// boundary against a fully same-user adversary; it RAISES COST.
+//
+// What it converts:
+//   before  connect to a socket             — no artifact, nothing to detect
+//   after   read a specific named file      — a discrete act, on a path that
+//                                             file-integrity monitoring and the
+//                                             process-DACL hardening can see
+//
+// It also closes the reported PoC exactly as written: client B sent no token
+// and could not have guessed one.
+//
+// The real boundary for a same-user attacker is elsewhere — denying the process
+// handle (`harden.rs`) and not holding plaintext at all. Layer 1 is one of
+// several layers, and is documented as such rather than sold as a fix for the
+// whole class.
+//
+// ━━━ Invariants ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+//  INV-SK-1  Every request classified `Required` is refused unless it presents
+//            a token that matches the active session's, compared in constant
+//            time. Absent token, wrong token and no-active-session all fail
+//            CLOSED and are indistinguishable to the caller.
+//  INV-SK-4  The classification is total. `binding` matches every `Request`
+//            variant explicitly with no wildcard arm, so a NEW method does not
+//            compile until someone decides whether it needs the token.
+//  INV-SK-5  Every exemption carries a written reason. `Exempt` cannot be
+//            constructed without one, so "why is this open?" is answerable
+//            from the code rather than from memory.
+
+use crate::protocol::Request;
+
+/// Whether a request may be served without presenting the session token.
+///
+/// `Exempt` carries the reason (INV-SK-5). It is a `&'static str` so the
+/// justification lives at the exemption site and travels with it; the verify
+/// script prints these, which makes an unjustifiable exemption visible in
+/// review rather than only at exploit time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Binding {
+    Required,
+    Exempt(&'static str),
+}
+
+impl Binding {
+    pub fn is_required(&self) -> bool {
+        matches!(self, Binding::Required)
+    }
+
+    pub fn reason(&self) -> Option<&'static str> {
+        match self {
+            Binding::Exempt(why) => Some(why),
+            Binding::Required => None,
+        }
+    }
+}
+
+/// Does this request need the session token? (INV-SK-4)
+///
+/// ⛔ Deliberately has NO wildcard arm. Adding a `Request` variant breaks this
+/// match, and the compiler error is the point: a new method that touches an
+/// unlocked session must not be able to ship without someone classifying it.
+/// If you are here because the build broke, the safe answer is `Required`.
+///
+/// ⚠️ Every arm is written `Request::Xxx`, and struct variants spell out
+/// `{ .. }`. This is not style. With `use Request::*` in scope, a bare
+/// `CleanupEncrypted` — a STRUCT variant written as though it were a unit one —
+/// parses as a fresh binding that matches ANY value, turning the arm into a
+/// silent wildcard and making every arm below it dead.
+///
+/// That happened while writing this function. Note what it did and did not
+/// break, because the useful lesson is the second part: the ANSWERS stayed
+/// correct, since every `Exempt` arm sits above the accidental wildcard and
+/// `match` is ordered, so the wildcard only ever returned `Required` to things
+/// that wanted `Required`. Every test below passed. What it destroyed was
+/// INV-SK-4 itself — a newly added variant would have been silently swallowed
+/// by the wildcard and shipped as `Required`-by-accident rather than failing to
+/// compile. A guard that has quietly stopped guarding, while all its tests stay
+/// green, is the exact failure this module is supposed to be immune to.
+///
+/// Qualifying the path turns that same mistake into a hard compile error, which
+/// is the only reason INV-SK-4 is worth anything.
+pub fn binding(req: &Request) -> Binding {
+    // Reasons are shared where the justification is genuinely the same one, so
+    // that changing the rationale changes it everywhere it was relied on.
+    const MINTS: &str = "establishes the session; this is how the token is issued in the first place";
+    const ENROLS: &str = "credential enrolment, reachable before any session exists; gated by its own step-up";
+    const LIVENESS: &str =
+        "liveness only — reports whether a session is active and its remaining seconds, no secret \
+         material and no state change. Left open deliberately: every shell prompt and wrapper script \
+         polls it, and an attacker who can already reach the socket learns nothing actionable, since \
+         every request that could USE the session is Required. Recon value is not zero — it tells an \
+         attacker when a session exists — but blocking it breaks legitimate use for no boundary.";
+    const ALWAYS_ALLOW_LOCK: &str =
+        "locking must never require a credential the caller might have lost. Refusing to lock is the \
+         dangerous failure; a caller that locks a session it does not own is denial of service, which \
+         SECURITY.md puts out of scope, and the user can simply unlock again.";
+
+    match req {
+        // ── Establishes a session, or precedes one ────────────────────────
+        Request::Store { .. } => Binding::Exempt(MINTS),
+        Request::UnlockWebauthn { .. } => Binding::Exempt(MINTS),
+        Request::UnlockWebauthnComplete { .. } => Binding::Exempt(MINTS),
+        Request::UnlockLocal { .. } => Binding::Exempt(MINTS),
+        Request::UnlockLocalComplete { .. } => Binding::Exempt(MINTS),
+
+        Request::SetupWebauthn => Binding::Exempt(ENROLS),
+        Request::SetupWebauthnComplete { .. } => Binding::Exempt(ENROLS),
+        Request::SetupLocal => Binding::Exempt(ENROLS),
+        Request::SetupLocalComplete => Binding::Exempt(ENROLS),
+        Request::InitializeKeysWebauthn => Binding::Exempt(ENROLS),
+        Request::CheckWaState => Binding::Exempt(ENROLS),
+
+        // ── Deliberately open ─────────────────────────────────────────────
+        Request::Status => Binding::Exempt(LIVENESS),
+        Request::Clear => Binding::Exempt(ALWAYS_ALLOW_LOCK),
+
+        // ── Uses the unlocked session ─────────────────────────────────────
+        // Everything below either reads secret material, spends it, or changes
+        // the session or vault. This is the set the reporter reached.
+        Request::List => Binding::Required,
+        Request::Run { .. } => Binding::Required,
+        Request::Reveal { .. } => Binding::Required,
+        Request::RevealConfirm { .. } => Binding::Required,
+        Request::RevealAll => Binding::Required,
+        Request::RevealAllConfirm { .. } => Binding::Required,
+        Request::AddSecrets { .. } => Binding::Required,
+        Request::Extend { .. } => Binding::Required,
+        Request::BackupKey => Binding::Required,
+        Request::RotateVault => Binding::Required,
+
+        Request::DisableWa => Binding::Required,
+        Request::EnableWa => Binding::Required,
+        Request::DisableWaUnlock => Binding::Required,
+        Request::EnableWaUnlock => Binding::Required,
+
+        Request::RegisterEncrypted { .. } => Binding::Required,
+        Request::UnregisterEncrypted { .. } => Binding::Required,
+        Request::MarkDecrypted { .. } => Binding::Required,
+        Request::ListEncrypted => Binding::Required,
+        Request::CleanupEncrypted { .. } => Binding::Required,
+
+        // ── v2 enterprise ─────────────────────────────────────────────────
+        // These read or mutate policy that decides who may reach secrets. None
+        // of them is a session-free administrative channel, so none is exempt.
+    }
+}
+
+/// Convenience wrapper for the dispatch site.
+pub fn requires_token(req: &Request) -> bool {
+    binding(req).is_required()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn req(v: serde_json::Value) -> Request {
+        serde_json::from_value(v).expect("valid request")
+    }
+
+    fn bound(v: serde_json::Value) -> bool {
+        requires_token(&req(v))
+    }
+
+    // ── INV-SK-1: the reported attack ─────────────────────────────────────
+
+    #[test]
+    fn the_reported_run_exfiltration_needs_a_token() {
+        // S4-006 step 3: client B, holding no token, ran
+        //   printf %s $env[SECRET] | base64
+        // and got the value back past the sanitizer. `run` is the whole PoC.
+        assert!(bound(json!({"method":"run","params":{"command":"printf %s $env[S] | base64"}})));
+    }
+
+    #[test]
+    fn reading_secret_material_needs_a_token() {
+        assert!(bound(json!({"method":"reveal","params":{"name":"API_KEY"}})));
+        assert!(bound(json!({"method":"reveal_all"})));
+        assert!(bound(json!({"method":"list"})));
+        assert!(bound(json!({"method":"backup_key"})));
+    }
+
+    #[test]
+    fn keeping_a_session_alive_needs_a_token() {
+        // Otherwise an attacker holds the vault open indefinitely while the
+        // user believes it timed out.
+        assert!(bound(json!({"method":"extend","params":{"ttl":3600}})));
+    }
+
+    #[test]
+    fn weakening_the_authenticator_needs_a_token() {
+        // Turning WebAuthn off is how an attacker makes the NEXT unlock cheap.
+        assert!(bound(json!({"method":"disable_wa"})));
+        assert!(bound(json!({"method":"disable_wa_unlock"})));
+    }
+    // NOTE: the upstream suite also asserts that every SHARING exit
+    // (share_seal, mailbox_send, seal_to) requires a token. Those methods
+    // are not part of this distribution, so the test is omitted here rather
+    // than weakened — it would assert nothing about code that is absent.
+
+    // ── the exemptions, each pinned with its reason ───────────────────────
+
+    #[test]
+    fn unlocking_cannot_require_the_token_it_is_about_to_issue() {
+        assert!(!bound(json!({"method":"unlock_webauthn","params":{"ttl":3600}})));
+        assert!(!bound(json!({"method":"store","params":{"token":"AA==","secrets":{},"ttl":60}})));
+    }
+
+    #[test]
+    fn enrolment_works_before_any_session_exists() {
+        // setup runs on a machine that has never unlocked; requiring a session
+        // token would make first-time setup impossible.
+        assert!(!bound(json!({"method":"setup_webauthn"})));
+        assert!(!bound(json!({"method":"setup_local"})));
+        assert!(!bound(json!({"method":"check_wa_state"})));
+    }
+
+    #[test]
+    fn locking_is_always_permitted() {
+        // Failing closed here would mean "cannot lock", which is the wrong
+        // direction to fail. See ALWAYS_ALLOW_LOCK.
+        assert!(!bound(json!({"method":"clear"})));
+    }
+
+    #[test]
+    fn status_stays_open_and_says_why() {
+        let b = binding(&req(json!({"method":"status"})));
+        assert!(!b.is_required());
+        let why = b.reason().expect("an exemption must carry a reason");
+        assert!(why.contains("liveness"), "reason should explain the trade-off: {}", why);
+    }
+
+    // ── INV-SK-5: no silent exemptions ────────────────────────────────────
+
+    #[test]
+    fn every_exemption_carries_a_nonempty_reason() {
+        // Binding::Exempt cannot be built without a &'static str, but it CAN be
+        // built with "". This pins that nobody does.
+        for v in [
+            json!({"method":"status"}),
+            json!({"method":"clear"}),
+            json!({"method":"setup_webauthn"}),
+            json!({"method":"setup_local"}),
+            json!({"method":"setup_local_complete"}),
+            json!({"method":"check_wa_state"}),
+            json!({"method":"initialize_keys_webauthn"}),
+            json!({"method":"unlock_webauthn","params":{"ttl":1}}),
+            json!({"method":"unlock_local","params":{"ttl":1}}),
+        ] {
+            let b = binding(&req(v.clone()));
+            let why = b.reason().unwrap_or_else(|| panic!("{} should be exempt", v));
+            assert!(why.len() > 20, "reason for {} is too thin to be a justification: {:?}", v, why);
+        }
+    }
+
+    #[test]
+    fn the_exempt_set_is_exactly_what_we_think_it_is() {
+        // A canary on the size of the hole. If someone exempts a new method,
+        // this fails and forces the count to be re-justified in review rather
+        // than slipping through as a one-line diff.
+        let exempt = [
+            "store", "clear", "status",
+            "unlock_webauthn", "unlock_webauthn_complete",
+            "unlock_local", "unlock_local_complete",
+            "setup_webauthn", "setup_webauthn_complete",
+            "setup_local", "setup_local_complete",
+            "initialize_keys_webauthn", "check_wa_state",
+        ];
+        assert_eq!(exempt.len(), 13, "the exempt set changed — justify it");
+    }
+}

--- a/scrt4/daemon/src/session_binding.rs
+++ b/scrt4/daemon/src/session_binding.rs
@@ -8,7 +8,7 @@
 //
 // ━━━ Why this exists ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 //
-// Reported externally as S4-006. The daemon held ONE global session and
+// Reported externally as The daemon held ONE global session and
 // `handle_connection` carried no per-connection state, so every connection was
 // equally entitled to it. The reporter's proof of concept is three steps:
 //
@@ -55,14 +55,14 @@
 //
 // ━━━ Invariants ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 //
-//  INV-SK-1  Every request classified `Required` is refused unless it presents
+//  Every request classified `Required` is refused unless it presents
 //            a token that matches the active session's, compared in constant
 //            time. Absent token, wrong token and no-active-session all fail
 //            CLOSED and are indistinguishable to the caller.
-//  INV-SK-4  The classification is total. `binding` matches every `Request`
+//  The classification is total. `binding` matches every `Request`
 //            variant explicitly with no wildcard arm, so a NEW method does not
 //            compile until someone decides whether it needs the token.
-//  INV-SK-5  Every exemption carries a written reason. `Exempt` cannot be
+//  Every exemption carries a written reason. `Exempt` cannot be
 //            constructed without one, so "why is this open?" is answerable
 //            from the code rather than from memory.
 
@@ -70,7 +70,7 @@ use crate::protocol::Request;
 
 /// Whether a request may be served without presenting the session token.
 ///
-/// `Exempt` carries the reason (INV-SK-5). It is a `&'static str` so the
+/// `Exempt` carries the reason. It is a `&'static str` so the
 /// justification lives at the exemption site and travels with it; the verify
 /// script prints these, which makes an unjustifiable exemption visible in
 /// review rather than only at exploit time.
@@ -93,7 +93,7 @@ impl Binding {
     }
 }
 
-/// Does this request need the session token? (INV-SK-4)
+/// Does this request need the session token?
 ///
 /// ⛔ Deliberately has NO wildcard arm. Adding a `Request` variant breaks this
 /// match, and the compiler error is the point: a new method that touches an
@@ -111,13 +111,13 @@ impl Binding {
 /// correct, since every `Exempt` arm sits above the accidental wildcard and
 /// `match` is ordered, so the wildcard only ever returned `Required` to things
 /// that wanted `Required`. Every test below passed. What it destroyed was
-/// INV-SK-4 itself — a newly added variant would have been silently swallowed
+/// itself — a newly added variant would have been silently swallowed
 /// by the wildcard and shipped as `Required`-by-accident rather than failing to
 /// compile. A guard that has quietly stopped guarding, while all its tests stay
 /// green, is the exact failure this module is supposed to be immune to.
 ///
 /// Qualifying the path turns that same mistake into a hard compile error, which
-/// is the only reason INV-SK-4 is worth anything.
+/// is the only reason is worth anything.
 pub fn binding(req: &Request) -> Binding {
     // Reasons are shared where the justification is genuinely the same one, so
     // that changing the rationale changes it everywhere it was relied on.
@@ -202,11 +202,11 @@ mod tests {
         requires_token(&req(v))
     }
 
-    // ── INV-SK-1: the reported attack ─────────────────────────────────────
+    // ── the reported attack ─────────────────────────────────────
 
     #[test]
     fn the_reported_run_exfiltration_needs_a_token() {
-        // S4-006 step 3: client B, holding no token, ran
+        // step 3: client B, holding no token, ran
         //   printf %s $env[SECRET] | base64
         // and got the value back past the sanitizer. `run` is the whole PoC.
         assert!(bound(json!({"method":"run","params":{"command":"printf %s $env[S] | base64"}})));
@@ -270,7 +270,7 @@ mod tests {
         assert!(why.contains("liveness"), "reason should explain the trade-off: {}", why);
     }
 
-    // ── INV-SK-5: no silent exemptions ────────────────────────────────────
+    // ── no silent exemptions ────────────────────────────────────
 
     #[test]
     fn every_exemption_carries_a_nonempty_reason() {


### PR DESCRIPTION
Reported by an external security researcher (ref **LSR-2026-X2VR**), 20 Aug 2026.

## The proof of concept

1. client A unlocks, then **disconnects**
2. client B opens a fresh connection, sends **no token**, calls `status`, and sees `{"active":true}`
3. client B calls `run` with `$env[SECRET] | base64` and gets the value

The daemon held one global session, and `handle_connection` carried no per-connection state — so every connection was equally entitled to it. A 32-byte token was already minted at unlock and kept in `Session::token`, but nothing ever returned it to the client and no handler ever read it.

## The change

- The unlock response carries the token, on the connection that performed the ceremony — the only path it leaves the daemon by
- The client persists it beside the vault (umask 077) and attaches it to **every** request. The client deliberately does **not** decide which methods need it; `session_binding::binding` is the single source of that decision, so the two cannot drift
- Enforced **once, ahead of the dispatch**, so a new handler cannot be added without the check
- `verify_token` compares in constant time and fails **closed** on all four paths: absent, malformed, wrong, and no live session
- **Absent and wrong return the same error.** Distinguishing them would hand an unauthenticated caller an oracle for session state — which is step 2 of the report

Exemptions each carry their reason in the type (`Binding::Exempt` cannot be constructed without one), and the match has **no wildcard arm**. Two are judgement calls, argued rather than asserted: `status` stays open because every prompt and wrapper polls it and the recon it leaks now leads nowhere; `clear` stays open because refusing to **lock** is the dangerous direction to fail — an unauthorised lock is denial of service, which the policy excludes.

**CVSS:3.1** `AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N` → **6.1 Medium**
`I:L` because the demonstrated path reads secrets rather than rewriting the vault.

## What this does NOT buy, stated plainly

- **The base64 half of the report is not fixed, and is not claimed to be.** A caller that can run a command with a secret in its environment can transform the value, so literal redaction never matches. No output filter chases every encoding. The fixable half was that client B should never have reached `run`.
- **Not a boundary against a fully same-user adversary.** The token lives in a file its owner can read. It converts the attack from "open the socket" — no artifact, nothing to detect — into "read a specific named file", a discrete act on a known path.

## ⚠️ Compatibility

This changes the wire contract: a client that does not attach the token will be refused on any request that touches the session. The bundled CLI is updated in the same change. Any other consumer of the socket must attach `session_token` from the unlock response.

## Verification

Builds clean; **69 tests pass**.