### PR TITLE
fix(cli): open the auth page locally on macOS/Linux, and drop the `setup agent` submode

### DIFF
--- a/scrt4/daemon/bin/scrt4-core
+++ b/scrt4/daemon/bin/scrt4-core
@@ -190,6 +190,25 @@ _has_gui() {
     command -v zenity >/dev/null 2>&1 || return 1
     [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]
 }
+
+# _has_desktop — is there a desktop that can show a browser window?
+#
+# Deliberately NOT _has_gui. That one asks a narrower question — "can I pop a
+# zenity dialog" — and answers it with zenity + $DISPLAY/$WAYLAND_DISPLAY, both
+# of which are X11/Wayland notions. macOS has neither, so _has_gui is false on
+# every Mac, and gating a browser launch on it silently skips the browser on the
+# one platform whose only local authenticator is Touch ID.
+_has_desktop() {
+    [ "${SCRT4_NO_GUI:-0}" = "1" ] && return 1
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        Darwin) return 0 ;;
+    esac
+    # WSL reaches the Windows shell, so a browser is available there too.
+    if command -v wslpath >/dev/null 2>&1 && command -v cmd.exe >/dev/null 2>&1; then
+        return 0
+    fi
+    [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]
+}
 export -f _has_gui
 
 # ── Standard panel helpers (scrt4 GUI contract) ──────────────────────
@@ -723,6 +742,24 @@ run_setup_flow() {
     echo -e "  Then tap 'Register Passkey' on the page."
     echo ""
 
+    # Also open the page on THIS machine, so a platform passkey (Touch ID,
+    # Windows Hello) can complete the ceremony without a phone. The Windows
+    # client has always done this; the Unix client only ever printed the QR,
+    # which is why `setup` on a Mac never reached Touch ID.
+    #
+    # full_url, not url: the wrapping key rides in the fragment, and a local
+    # browser needs it. The QR keeps using the same value, so nothing about
+    # what the phone receives changes.
+    #
+    # Agent mode is excluded — it can't see a browser window, and its whole
+    # purpose is a scrapeable terminal QR.
+    if [ "$FORCE_CLI" = false ] && _has_desktop; then
+        open_ceremony_browser "$full_url"
+        echo -e "  ${CYAN}(opened in your browser — use Touch ID / Windows Hello there,${NC}" >&2
+        echo -e "  ${CYAN} or scan the QR with your phone)${NC}" >&2
+        echo "" >&2
+    fi
+
     local payload=""
     if [ "$FORCE_CLI" = false ] && _has_gui; then
         payload=$(poll_relay_gui "$session_id" "$url") || {
@@ -1151,7 +1188,12 @@ cmd_setup() {
         case "$1" in
             --local)     use_local=true; shift ;;
             --agent)     AGENT_MODE=true; FORCE_CLI=true; shift ;;
-            --cli|agent) FORCE_CLI=true; shift ;;
+            # The bare `agent` submode is gone: the command is just `scrt4
+            # setup`. `--agent` still exists for AI-agent callers that need the
+            # terminal QR, and a stray `agent` argument now falls through to the
+            # catch-all below, so `scrt4 setup agent` still works and simply
+            # means `scrt4 setup`.
+            --cli)       FORCE_CLI=true; shift ;;
             *)           shift ;;
         esac
     done
@@ -2705,7 +2747,7 @@ cmd_llm() {
                 cloud_crypt_auth: $cc_auth
               },
               setup_commands: {
-                register_passkey:           "scrt4 setup agent",
+                register_passkey:           "scrt4 setup --agent",
                 unlock:                     "scrt4 unlock",
                 cloud_crypt_auth_gws:       "scrt4 cloud-crypt auth setup --from-gws",
                 cloud_crypt_auth_existing:  "scrt4 cloud-crypt auth setup --from-secret personal_google_workspace",

--- a/scrt4/install/scrt4-native.sh
+++ b/scrt4/install/scrt4-native.sh
@@ -354,7 +354,7 @@ main() {
     printf '\n' >&2
     printf '\033[0;32mscrt4-native: installed.\033[0m\n' >&2
     printf 'Next:\n' >&2
-    printf '  1. scrt4 setup agent     # enroll your FIDO2 authenticator\n' >&2
+    printf '  1. scrt4 setup           # enroll your passkey (Touch ID / Hello / phone)\n' >&2
     printf '  2. scrt4 unlock          # 20-hour session\n' >&2
     printf '  3. scrt4 quickstart      # readiness snapshot\n' >&2
     printf '  4. scrt4 help            # full command list\n' >&2

--- a/scrt4/windows/package.ps1
+++ b/scrt4/windows/package.ps1
@@ -52,7 +52,36 @@ $ErrorActionPreference = 'Stop'
 $running = Get-Process -Name 'scrt4-daemon' -ErrorAction SilentlyContinue
 if ($running) {
     Write-Host 'Stopping running scrt4-daemon...' -ForegroundColor Yellow
-    $running | Stop-Process -Force; Start-Sleep -Milliseconds 500
+    # Stop each daemon on its own, and do not let one failure abort the install.
+    # $ErrorActionPreference is 'Stop' in this script, so `$running |
+    # Stop-Process -Force` used to throw on the FIRST process it could not kill
+    # -- typically one started from an elevated shell, which a normal user
+    # cannot touch -- and terminate the installer right here, before a single
+    # file was copied. All the caller saw was "Installer exited with code 1",
+    # with nothing said about which process or what to do about it.
+    $stuck = @()
+    foreach ($proc in @($running)) {
+        try { Stop-Process -Id $proc.Id -Force -ErrorAction Stop }
+        catch { $stuck += $proc }
+    }
+    Start-Sleep -Milliseconds 500
+    if ($stuck.Count -gt 0) {
+        Write-Host ''
+        Write-Host 'Could not stop these scrt4-daemon processes:' -ForegroundColor Red
+        foreach ($proc in $stuck) {
+            $when = 'unknown start time'
+            try { $when = 'started ' + $proc.StartTime.ToString('yyyy-MM-dd HH:mm') } catch { }
+            Write-Host ("  PID {0}  ({1})" -f $proc.Id, $when) -ForegroundColor Red
+        }
+        $ids = ($stuck | ForEach-Object { $_.Id }) -join ','
+        Write-Host ''
+        Write-Host 'They are almost certainly running elevated. In an Administrator terminal:' -ForegroundColor Yellow
+        Write-Host ("  Stop-Process -Id {0} -Force" -f $ids) -ForegroundColor Yellow
+        Write-Host 'then run this installer again.' -ForegroundColor Yellow
+        Write-Host ''
+        Write-Host 'Nothing was changed; your existing install is intact.' -ForegroundColor Yellow
+        exit 1
+    }
 }
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null


### PR DESCRIPTION
Two changes to the Unix CLI, both about `scrt4 setup` behaving the same way on every OS.

## 1. `setup` never opened a browser on macOS or Linux

The Windows client shows the QR **and** opens the auth page locally, so a platform passkey can finish the ceremony with no phone:

```powershell
# Native Windows: also open the auth page locally so a desktop
# passkey (Windows Hello) can complete the ceremony without a phone.
Start-Process $Url
```

The Unix client only ever printed the QR — `run_setup_flow` calls `show_qr_terminal` and `trigger_push`, and never `open_browser`/`open_ceremony_browser`.

On macOS that's the difference between "registers with Touch ID" and "there is no way to reach Touch ID at all". The relay page was never the problem: `detectPlatform()` already returns `mac` and pins `authenticatorAttachment: "platform"`. **Nothing ever navigated to it.**

| | before | after |
|---|---|---|
| Windows | QR + browser → Hello | unchanged |
| **macOS** | **QR only — Touch ID unreachable** | **QR + browser → Touch ID** |
| Linux (desktop) | QR only | QR + browser |
| Linux (headless) | QR only | unchanged |
| agent mode (`--agent`) | QR only | unchanged |

### Why a new `_has_desktop` and not `_has_gui`

`_has_gui` answers a narrower question — *"can I pop a zenity dialog"*:

```sh
command -v zenity >/dev/null 2>&1 || return 1
[ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]
```

zenity is GTK and `$DISPLAY`/`$WAYLAND_DISPLAY` are X11/Wayland notions. macOS has none of them, so **`_has_gui` is false on every Mac**. Gating a browser launch on it would have skipped the browser on the one platform whose only local authenticator is Touch ID. `_has_gui` is left alone — it's correct for what it does.

### Security note

The local browser gets `full_url`, not the shortened `url`: the wrapping key rides in the **fragment**. What the phone receives is unchanged.

## 2. `scrt4 setup agent` → `scrt4 setup`

The bare `agent` submode is removed from `cmd_setup`. It is **not** an error — a stray `agent` falls through to the catch-all, so the old invocation still works and simply means `scrt4 setup`.

`--agent` is untouched for callers that need the terminal QR, and the capability map now advertises the flag rather than the submode. The installer's post-install step 1 said `scrt4 setup agent` — that's where most people met it.

## Evidence

`bash -n` passes on both files.

```
_has_desktop
  Darwin DISPLAY='' NO_GUI=0    -> true   PASS
  Linux  DISPLAY='x11'          -> true   PASS
  Linux  DISPLAY='' (headless)  -> false  PASS
  Darwin SCRT4_NO_GUI=1         -> false  PASS

cmd_setup parsing
  scrt4 setup                -> local=false cli=false agent=false
  scrt4 setup agent          -> local=false cli=false agent=false   # == plain setup
  scrt4 setup --agent        -> local=false cli=true  agent=true
  scrt4 setup --cli          -> local=false cli=true  agent=false
  scrt4 setup --local        -> local=true  cli=false agent=false
  scrt4 setup --local --agent-> local=true  cli=true  agent=true
  scrt4 setup bogus          -> local=false cli=false agent=false
```

`_has_desktop` was tested with a scrubbed `PATH` and a stub `uname`, so the WSL branch could not mask the result.

## Not covered here

If a Mac's platform authenticator lacks the **PRF extension**, this gets you to Touch ID and the ceremony then fails with *"Your passkey provider does not support PRF."* That's a capability limit (iCloud Keychain gained PRF in macOS 15 / Safari 18), not a bug — `open_ceremony_browser` already prefers Chrome for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)